### PR TITLE
Change capital of Kiribati to South Tarawa

### DIFF
--- a/src/data/capital.csv
+++ b/src/data/capital.csv
@@ -200,7 +200,7 @@ Palau,Ngerulmud,Ngerulmud,Ngerulmud,Melekeok,Ngerulmud,Ngerulmud,Нгерулм�
 Saint Lucia,Castries,Castries,Castries,Castries,Castries,Castries,Кастри,Castries,Castries
 Grenada,St. George's,St. George's,Saint George,Saint-Georges,St. George's,Saint George's,Сент-Джорджес,Saint George's,Saint George's
 Curaçao,Willemstad,Willemstad,Willemstad,Willemstad,Willemstad,Willemstad,Виллемстад,Willemstad,Willemstad
-Kiribati,Tarawa,Tarawa,Tarawa,Tarawa,Bairiki (på Tarawa øy),Tarawa,Тарава,Tarawa,Tarawa
+Kiribati,South Tarawa,South Tarawa,Tarawa Sur,Tarawa-Sud,South Tarawa,"Tarawa (Jižní Tarawa)",Южная Тарава,Zuid-Tarawa,South Tarawa
 Marshall Islands,Majuro,Majuro,Majuro,Majuro,Majuro,Majuro,Маджуро,Majuro,Majuro
 Nauru,Yaren,Yaren,Yaren,Yaren,Yaren,Yaren,Ярен,Yaren,Yaren
 New Caledonia,Nouméa,Nouméa,Numea,Nouméa,Nouméa,Nouméa,Нумеа,Nouméa,Nouméa


### PR DESCRIPTION
As @ohare93 had mentioned in https://github.com/anki-geo/ultimate-geography/issues/166#issuecomment-632590049, Wikipedia changed back to South Tarawa a while back and the change hasn't been reverted since. Also, all languages seem to agree. See #416 for more details.