### PR TITLE
Add a link to a blank world map to desc.html

### DIFF
--- a/src/headers/desc.html
+++ b/src/headers/desc.html
@@ -12,4 +12,6 @@ The deck is available in <a href="https://github.com/axelboc/anki-ultimate-geogr
 
 You can use Anki's <a href="https://github.com/axelboc/anki-ultimate-geography#custom-study">filtered deck feature</a> to focus your study on a subset of the deck, such as sovereign states, a single note template (e.g. map to country), or a specific continent (e.g. Europe).
 
+You can use a <a href="https://upload.wikimedia.org/wikipedia/commons/4/4d/BlankMap-World.svg">blank world map</a> when training with this deck to have a visual reference.
+
 This deck is <a href="https://github.com/axelboc/anki-ultimate-geography"><b>maintained on GitHub</b></a>. If you spot a mistake, have a suggestion or want to help, please don't hesitate to <a href="https://github.com/axelboc/anki-ultimate-geography/issues">open an issue</a>. Want to <b>stay informed of new releases</b>? Watch the GitHub repository or subscribe to the <a href="https://github.com/axelboc/anki-ultimate-geography/releases.atom">releases feed</a>!


### PR DESCRIPTION
I found having a blank world map available extremely helpful for pointing at a physical map when being asked where a card is located.
So I linked to one resource on wikimedia that is similar to the map in the deck