### PR TITLE
Disambiguate capital of Northern Cyprus in Swedish

### DIFF
--- a/src/data/capital.csv
+++ b/src/data/capital.csv
@@ -205,7 +205,7 @@ Marshall Islands,Majuro,Majuro,Majuro,Majuro,Majuro,Majuro,Маджуро,Majuro
 Nauru,Yaren,Yaren,Yaren,Yaren,Yaren,Yaren,Ярен,Yaren,Yaren
 New Caledonia,Nouméa,Nouméa,Numea,Nouméa,Nouméa,Nouméa,Нумеа,Nouméa,Nouméa
 Niue,Alofi,Alofi,Alofi,Alofi,Alofi,Alofi,Алофи,Alofi,Alofi
-Northern Cyprus,North Nicosia,Nord-Nikosia,Nicosia del Norte,Nicosie-Nord,Nord-Nikosia,Severní Nikósie,Северная Никосия,North Nicosia,Nicosia
+Northern Cyprus,North Nicosia,Nord-Nikosia,Nicosia del Norte,Nicosie-Nord,Nord-Nikosia,Severní Nikósie,Северная Никосия,North Nicosia,Norra Nicosia
 Saint Kitts and Nevis,Basseterre,Basseterre,Basseterre,Basseterre,Basseterre,Basseterre,Бастер,Basseterre,Basseterre
 Samoa,Apia,Apia,Apia,Apia,Apia,Apia,Апиа,Apia,Apia
 Somaliland,Hargeisa,Hargeysa,Hargeisa,Hargeisa,Hargeisa,Hargeysa,Харгейса,Hargeisa,Hargeisa


### PR DESCRIPTION
Thanks @emiham (and thanks @axelboc for noticing this in the first place)!

Fix #437.

I'm not touching the Dutch version of North Nicosia ("North Nicosia" vs. "Noord-Nicosia" or something similar), for the moment!