### PR TITLE
Change the colliding French and Norwegian GUIDs

### DIFF
--- a/src/data/guid.csv
+++ b/src/data/guid.csv
@@ -1,308 +1,308 @@
 country,guid,guid:de,guid:es,guid:fr,guid:nb,guid:cs,guid:ru,guid:nl,guid:sv
-England,e+/O]%*qfk,7rv=E6qjR%,6=u<D5pin$,6=u<D5pin$,e+/O]%*qfk,C{]JF%%mr*,Jm&ky}FZz?,K`AixN?4fO,M@9EfpNi;z
-Scotland,h~5xz+=ke~,!Le9##zdQ2,9hd8!!ycm1,9hd8!!ycm1,h~5xz+=ke~,CzhyKE{%zy,bms0vPoZ2i,yM2(NER.TK,Gpeah<lh@u
-United Kingdom,s9-GL*@AXD,.it+:!Ct{^,-*s*/9Bs5],-*s*/9Bs5],s9-GL*@AXD,uMj[iKx*FT,OIwD?Vq[H},Ca99PA=59O,"nN,;(#X}Wt"
-Northern Ireland,cPO|Cru8n<,5>=J&k61ZP,4X<I%j50vO,4X<I%j50vO,cPO|Cru8n<,t2Q}Uw:@3V,b9(smVRG!j,"oTXQ,6j^=,",b4O.fdq=&&
-France,m*#%sE.`.;,(qkm4xu>uO,&<jl3wt=@N,&<jl3wt=@N,m*#%sE.`.;,qd!suvo&1v,G=a}N]t`St,z&9OM<varw,pk+~~g89%y
-Wales,hNE9}>;Q&-,!<)iK-xJnK,"9V(hJ,wI/J","9V(hJ,wI/J",hNE9}>;Q&-,zT0L2L~T>H,ry#$]bo`k},plhRl:Tz/O,Ae@YR@cdSW
-Georgia,jN|NAUP*h},$<J<$N>!T1,#VI;#M=9p0,#VI;#M=9p0,jN|NAUP*h},rNr_y>Sm<E,hE`:7lrR4P,F5Vc$<OC20,h>OmJ~oZ~|
-Germany,"j|z@PMgdx,",$J#C>FS{9J,#f!B=ER`FI,#f!B=ER`FI,"j|z@PMgdx,",vt!WOLxZl$,Qhq[TBO5H),HM%kKM-7l.,gM+}.:OZH]
-Greece,n+t>2`:;P/,)r5Ab>w*>M,(=4za=v)XL,(=4za=v)XL,n+t>2`:;P/,nG#=Zxp5Qn,yT?~lnZ:gX,O8/WkWCPZP,wH[5PSfX;K
-Greenland,ilGtw#=asM,#X+584z^4c,!t*473y]Ab,!t*473y]Ab,ilGtw#=asM,l]+1ZOhWt<,jI?2qf!yDb,e(k0BGyL4h,Qi.AoC*UvT
-Hungary,mcc&0Kq^xE,(OOn~D2<9_,&kNm}C1;F^,&kNm}C1;F^,mcc&0Kq^xE,u3}~&(A[aZ,w]]>DB_&l`,"z+,{cjN9md",j^H$O[w*tW
-Albania,gz9${p}er*,9#ilIiK|3H,8HhkHhJ{zG,8HhkHhJ{zG,gz9${p}er*,noQ|9=PqcG,PiubQg^Ss5,Hp1dL9r:*P,O:){fAE+[h
-Andorra,dY96`C-f(_,6|ifHvt}oX,56heGus|:W,56heGus|:W,dY96`C-f(_,A7Cj*hqC7[,I7y6V2sDdB,CY;OB`EDX7,KUSv4_ZftC
-Austria,r>aI-$$|wT,-AM-t5l@8j,",{L,s4k?Ei",",{L,s4k?Ei",r>aI-$$|wT,pbX.~.6OJO,v~cPQn}Wc%,p((H!2~3O7,f`?#zj#)DE
-Azerbaijan,"k9E.p^<u$,",%i)u1<ynlJ,$*(t0;xm-I,$*(t0;xm-I,"k9E.p^<u$,",AQZNs:<Ihn,b}AIti8H8S,oW=/gF6ZOL,"x]u},H#?K~"
-Belarus,l$zM~ihPFE,&l#;LbTI*_,%-!:KaSHN^,%-!:KaSHN^,l$zM~ihPFE,D8N9aGT(YL,kOtGr;P3}k,Cx2EH*D>}Z,"B,[GBme-:n"
-Belgium,jTNoKo}Bu+,$]<0/hKu6I,#1;Z.gJtCH,#1;Z.gJtCH,jTNoKo}Bu+,gM5c_bst5A,pJE)w+ZJK%,LW*h#/!%&m,rF%zt5M&?-
-Bosnia and Herzegovina,mz[>>AxIr4,(#DAAt9B3u,&HCzzs8Azt,&HCzzs8Azt,mz[>>AxIr4,Pqi/=VQrpE,?R^lQY*D*,cU)|/vPi6j,z9T_hmmT*f
-Bulgaria,u4^lH.xem5,":dFX,&9|Yv",/$EW+%8{uu,/$EW+%8{uu,u4^lH.xem5,e%6%K/Fo7O,n8DMh4+UMz,M5*2c!ENJ`,v3/LK?TI+
-Croatia,bk2ByZIeU+,4Wb%!S-|^I,"3sa$9R,{2H","3sa$9R,{2H",bk2ByZIeU+,B&Pa`TK.W@,DNb~sC&J5%,ed!}~imM[!,GO8K><b?f2
-Czech Republic,twrhzJ[k:Z,/83T#CDdwp,.E2S!BCc]o,.E2S!BCc]o,twrhzJ[k:Z,gMpU6QZpk{,if&Ipt4{R!,pV`:gi7=r2,wR=%k%E3:i
-Denmark,kS)hDm%w}R,%[pT(fmpKh,$0oS&elogg,$0oS&elogg,kS)hDm%w}R,xT>UY=~g;v,gd(%cHqsMU,d!lJ)zdUTJ,wh@G!lN$Q|
-Estonia,"AES],s:8=","t)iVs4wh,",sMhU>3vg+,sMhU>3vg+,"AES],s:8=",y29//}tZ9$,paYW617a]n,gGm>+9`k&,w2^A.*A;0^
-Faroe Islands,k[)#L4.[v3,%Dpk:Xu:7t,$~oj/Wt/Ds,$~oj/Wt/Ds,k[)#L4.[v3,LKI5~A(OZ!,qLh1v`1iQr,dG[-P1]Ly-,ca`<lL]SBn
-Finland,k}A9]O:0xw,%K$iEHwT9<,$g#hDGvSF;,$g#hDGvSF;,k}A9]O:0xw,Q`OBBA(IqJ,f6}E@C#_3N,rd_(OgnX-P,lsc1G{vU4.
-Iceland,j7eEZkzsCZ,$gQ)}d#l&p,#(P(|c!kKo,#(P(|c!kKo,j7eEZkzsCZ,BCT|*-aN8t,x4g!MZegS},trUg0y&dqG,C[bMs5PN|d
-Ireland,s<_WLSB3I/,.yG`:L%W-M,-_F_/K$VQL,-_F_/K$VQL,s<_WLSB3I/,"l]B_A,?ph!",Gir-4TL#W$,p/C10M3xxF,DVc[0B1#@*
-Italy,cYKvF#ptF7,5|/7*41m*x,46.6)30lNw,46.6)30lNw,cYKvF#ptF7,p2-()%uZj7,"A,M2k`~Wd[",COfUkybfx],P;wx%Rx}g%
-Latvia,m)WUtJS`H&,"(p`^5C[>,E",&;_]4B@=PD,&;_]4B@=PD,m)WUtJS`H&,It2!t/-o?>,ld2~^b3]8e,"lQZ,yi}j,|",i3-W.8A8pC
-Liechtenstein,l$2O|9w`F~,&lb=J28>*2,%-a<I17=N1,%-a<I17=N1,l$2O|9w`F~,M*;rH]4K.>,B}gk}F/NJD,c7Zh2xn$t_,x^M8w2)s#:
-Lithuania,kZ52zV#[Iv,%}eb#Ok:-;,$7da!Nj/Q:,$7da!Nj/Q:,kZ52zV#[Iv,HqC57O<OYN,P<8J|ziSx_,e=OVM]`Q{U,ODx_iYAqK(
-Luxembourg,i2]v|D3@:j,#bE7Jwc/w$,!!D6Ivb.]#,!!D6Ivb.]#,i2]v|D3@:j,wO[~:de]T,GvL1T<pl)T,"byp9L/7/,y",oU<~4jjCyP
-North Macedonia,r5C646H*+*,"-e&fdZ,!rH",",%%ecY+9=G",",%%ecY+9=G",r5C646H*+*,B*Me@Zh_[S,H[sth&^jGj,"HL//^#,,5X",A&@FdL>j&h
-Malta,nIfRn<aY:N,)-R@Z+MRwd,(QQ?Y*LQ]c,(QQ?Y*LQ]c,nIfRn<aY:N,"f=(W,pEE)M",Qz/GWg%Oi,pfZC2}Oawc,dnY]_1$e<W
-Moldova,5S(f7%O-$,Y[F8gm=t5,X0E7(l<s4,X0E7(l<s4,5S(f7%O-$,mn{KoGN.?b,st{N3o<qmk,s!x^ui`nhG,u<w5s|M#Ds
-Monaco,m?}%V6s8]*,(BKm_Z41EH,&|Jl^Y30aG,&|Jl^Y30aG,m?}%V6s8]*,pL;e7uiX=l,"hs,ph6r@5",kYE~9)8V#3,JO{1$2yxOD
-Montenegro,uRo^w#p5Be,:@0F841Y%7,/ZZE730XJ6,/ZZE730XJ6,uRo^w#p5Be,D!-|+!*eBX,Gn220)gYMN,p#WecI-Q`c,l*S7j866t<
-Netherlands,"o=,%hU&yX%",*zsmTNnr{D,)`rlSMmq5C,)`rlSMmq5C,"o=,%hU&yX%",F-eGLxAZDt,ImiWQfE/Wg,ca6|9M[|.3,I}xtas*<<=
-Norway,lq`T^ZBF2Y,&2H]FS%ybo,%yG[ER$x!n,%yG[ER$x!n,lq`T^ZBF2Y,xaacSwZi[n,A`|*K1}2WV,K0`3{Z#>H&,HX#;I12-Gu
-Poland,f>c7x2E]Q6,8AOg9V);?w,7{Nf8U(:Yv,7{Nf8U(:Yv,f>c7x2E]Q6,PSEKL{AHnb,wz:QAN8%&+,QYr^22xCo3,O|!r8pZc_@
-Portugal,"q[S4`,F0D=",",D[dH$*T(Q",+~@cG#)SLP,+~@cG#)SLP,"q[S4`,F0D=",Hx}kMe>iu~,elHzZb0RD>,MjYBzKMsYj,c0X`Rdpvdg
-Romania,"jCd]`-=k,:",$&PEH%zdsN,#KODG$yc>M,#KODG$yc>M,"jCd]`-=k,:",uv?Z2p<%;s,EEpm1lUrG],iOD+[;vOc1,QO[lJt~Q]N
-Russia,vf)G?[_?Pf,;Rp+B:G.>8,:no*A/F-X7,:no*A/F-X7,vf)G?[_?Pf,M%Zo)4Ex%5,fmanrW{ILh,i`?s5yONk<,u3u7Z|VQV`
-San Marino,"j9:K,~DQ2v",$iw/s](Jb;,#*v.r[&I!:,#*v.r[&I!:,"j9:K,~DQ2v",MY>?+-m40S,drS3F@Hxm;,NIKs(pApAY,t%PfM!!RPu
-Serbia,ui3>b-?a@m,:UcAN%B^C(,/qbzM$A]}&,/qbzM$A]}&,ui3>b-?a@m,KM9;RF<Oa9,vC~!WO}1Yx,"OQK^$9xbg,",A:WhEL~x!A
-Slovakia,qVi;t%/`F|,",_Ux56v>*0",+3Tw45u=NZ,+3Tw45u=NZ,qVi;t%/`F|,jpd^m*aK7%,Cz:.t]Ga.k,u>]sc0f?(|,d&Z;v4SLqS
-Slovenia,g-]bb&[.E!,9tENN7D&)A,8?DMM6C%Mz,8?DMM6C%Mz,g-]bb&[.E!,"hRH,A7qwWn",pQlr/JYlFs,fQMbKoTu%<,H/1j+}vOwc
-Spain,f21=-A~W;~,8bazttLPx2,7!~yssKO^1,7!~yssKO^1,f21=-A~W;~,k[^`V_WQ^I,Q-1OO^)n>C,P+Jx`aqYih,qv@;*gj=VH
-Sweden,sT5=H|@KU|,".]ez,@CD^0",-1dy+?BC2Z,-1dy+?BC2Z,sT5=H|@KU|,"AhCfC]V,BF",erbhQg!RK],b.r+%C+uUG,IlH%F{np<[
-Switzerland,lU@C3<C8Wk,&^C&c+&1`%,%2B%b*%04$,%2B%b*%04$,lU@C3<C8Wk,JD*D+bih|F,gyBy@/*]JR,KRSC>TBXX(,s=)J}uTu.N
-Turkey,jDA-V?/hVj,$($t_.va_$,#L#s^-u~3#,#L#s^-u~3#,jDA-V?/hVj,wM29>6E7w2,fn`TSL4H+K,Bo5dwc%z#M,GilXrl.A_%
-Ukraine,h_9=mkZXAH,!GizYd}Q$|,9chyXc|PI{,9chyXc|PI{,h_9=mkZXAH,Lh8)I$R;q>,"w,s~/*1#Rg",C_6GTKD=fH,q*^h!N31k*
-Vatican City,mk1VltJl<],(Wa_Xm.eyV,&s~^Wl-d_U,&s~^Wl-d_U,mk1VltJl<],c@Ms0SL)sn,E9ORP)qdh9,msv?k9JTsv,xc^[E/Z[$R
-Armenia,"c(,2{yXI#E",5osbIr{Bk_,"4:raHq`A,^","4:raHq`A,^","c(,2{yXI#E",G4t&;Hch6N,ERCyEa-V]o,s3s^.)4kHT,(;;{-bktU
-Cyprus,kkbYQXw5b;,%WN|?Q8YNO,$sM{>P7XjN,$sM{>P7XjN,kkbYQXw5b;,iP!?$Z_Ki5,A1fj8m}V_0,e90l[|lH!I,"FOI,VR<;HS"
-Kazakhstan,ia8as9sCY|,#MhM424v|0,!igL313u6Z,!igL313u6Z,ia8as9sCY|,p|~)@{)+S*,pwG/f8TA%+,"K[L!R^!9Z,",b2;iz|xg^@
-Egypt,j%*8gN)q>d,$mqhSGpjA6,#.pgRFoi{5,#.pgRFoi{5,j%*8gN)q>d,JJzRb!:b#h,LN}*YP~{-L,sM=)Xv_Xa-,uVs:]g8l.&
-Algeria,bd~Ght5tLR,4PL+Tmem:h,3lK*SldlTg,3lK*SldlTg,bd~Ght5tLR,z^#eqWYO-D,hb~_{qK>D=,v&-O]]=OEZ,FBWKraq$]`
-Angola,onMKID2d;D,*Z;/-wb{x^,")v:.,va`^]",")v:.,va`^]",onMKID2d;D,m.mLjg-{lM,gCZT`M|9xu,sGn#POf<9-,F[Hq;*V/7K
-Benin,"q8fF$4,c6_",",hR*lXs`fX",+)Q)kWr_&W,+)Q)kWr_&W,"q8fF$4,c6_",Qt7ILf!6y2,"ssdH.@,b*<",Pc50gy=WZl,[&[K^KiK8
-Botswana,upiX0g1quR,:1U{~~aj6h,/xT`}}~iCg,/xT`}}~iCg,upiX0g1quR,naB8r`cM^+,H16eX1]VWw,Mmj=@>?Sx{,mSow!CwtLI
-Burkina Faso,n:7&>YT5A=,)wgnAR]Y$Q,(]fmzQ[XIP,(]fmzQ[XIP,n:7&>YT5A=,xMDjNS>?hL,I!PNDUSvR|,q-&Hq~16&{,J.*@Nk4>0*
-Cameroon,j2IQ=f=w3@,$b-?z}zpcT,"#!,>y|yo#S","#!,>y|yo#S",j2IQ=f=w3@,DBo3+cT-[:,Nf8Q{=WT+v,e8|;;S>xQ.,B;S:<cu0^C
-Burundi,EWXNc<g5),x`ndOySe9,w4mckxRd8,w4mckxRd8,EWXNc<g5),v/ymm:8cf7,hEB<R*c15),A+}@K7X|kA,"B7hcD[}|,:"
-Cape Verde,gFOojQO(MH,9*=0VJ=8;|,8N<ZUI<7U{,8N<ZUI<7U{,gFOojQO(MH,vI7@NGK_Rr,b6L`KDbdIg,zumu&z#g.>,n$t4JTV.L[
-São Tomé and Príncipe,gePC:Xt_nW,9Q>&wQ5=Zm,8m=%vP4<vl,8m=%vP4<vl,gePC:Xt_nW,"dt/qfm,mMR",jOH{z(39<b,sp;kVFWNG~,"we!,qZc~VX"
-Central African Republic,vNiD6A.v#s,;<U(ftuok.,":VT&estn,-",":VT&estn,-",vNiD6A.v#s,I/zO]{Q@(q,hqBB(<N!^q,Bapr]RwJ#?,P.ls/JP5<}
-Chad,?n!)c/h=Q,.ZAGOvTzJ,-vzFkuSyI,-vzFkuSyI,?n!)c/h=Q,InSmtkntKP,dozwSc3oL_,IuT|OM*Nw~,ljuf!A77m!
-Equatorial Guinea,gYIoR`|AxW,9|-0@>Jt9m,"86,Z?=IsFl","86,Z?=IsFl",gYIoR`|AxW,m-W32Cjt+v,xD;}}nO&|5,q>9E7+;4K.,m9{}Vj*h)B
-Kenya,j<egqG@)EL,$yQS2zC9)b,#_PR1yB8Ma,#_PR1yB8Ma,j<egqG@)EL,u?7-e.O&if,H^_J<Y5+Lq,BP[&G+`3;|,hB_EsBpVEy
-Comoros,t`cagaWApo,/HOMS^`t1*,.dNLR]_sx),.dNLR]_sx),t`cagaWApo,bu.JnK@qu%,taEpjjAUDi,EjFv^:qmnZ,"k$T,&qpZ_E"
-Ivory Coast,jN^Vc%9OQ5,$<F_O6iH?v,#VE^N5hGYu,#VE^N5hGYu,jN^Vc%9OQ5,L!)340&$>j,"CP<0cpy;,I",f($keyMpus,B`1@FnD9*.
-Democratic Republic of the Congo,o3VS!KWb/@,*c_[jD`_vT,)#^@iC_^[S,)#^@iC_^[S,o3VS!KWb/@,IEVE(R=UT_,Q!DmMRZl:C,xLWoq0vCna,Nky*kq6)GC
-Djibouti,iR;U<J:CJJ,#@x^yCwv.~,!Zw]xBvuR},!Zw]xBvuR},iR;U<J:CJJ,f;ryKmL?JH,e@]nUPgXPS,i%DV(Dbx=K,dJX+VxBemo
-Guinea-Bissau,i^J8&$(1]|,#F.hn5oUE0,!b-gm4nTaZ,!b-gm4nTaZ,i^J8&$(1]|,vg&(+g]]yT,JumHq-w(@9,Neqxx;S4OH,ugyWN%[pXR
-Eritrea,pS>DrFhd%u,+[A(3yT{m:,*0z&2xS`./,*0z&2xS`./,pS>DrFhd%u,G4?YxB/<HP,NgIL<U_<X{,GmH*JA[[k`,w5=:(t5%R6
-Ethiopia,t|h3|;E4g{,/JTcJ*)XSZ,.fSbI)(WoY,.fSbI)(WoY,t|h3|;E4g{,q<##9ET8w4,g_banf#h(Q,s5?gh*QP;:,E[0uav)J05
-Gabon,p.yv>BQ470,+u!7Au?Xgq,*@96zt>W(p,*@96zt>W(p,p.yv>BQ470,Nz_#ah$j&d,A4mx0mYQ.6,eCQL}h5w8Y,FGu[yfPiJ7
-The Gambia,f#4-L[mp5*,8kdt::YieH,"7,cs//Xh%G","7,cs//Xh%G",f#4-L[mp5*,IoHWaA78;3,F9=}W4o(m(,i$q|D&dUr3,nh!${YsPie
-Lesotho,oNpApS<AoJ,*<1$1Lyt0~,)V0#0Kxsw},)V0#0Kxsw},oNpApS<AoJ,t(:iXC>cS>,"l_u,7Sl);4",tZgE~cq(oF,bkjWZ<Vg]U
-Liberia,"nsS59c`VL,",)4[ei`HO:J,(A@dh_GNTI,(A@dh_GNTI,"nsS59c`VL,",w~5sD@C~%!,sp#%Uu{jxI,qL:(ZnK[{b,KWY%fKd5dT
-Madagascar,m{noqE29%I,(IZ02xb2m},&eYZ1wa1.|,&eYZ1wa1.|,m{noqE29%I,p;&<%/w5b|,O>:Y)[/m@5,mB&*r_Fpq%,w3V@j|Foq~
-Malawi,sSW/?WMy17,.[`vBP;rax,-0_uAO:q9w,-0_uAO:q9w,sSW/?WMy17,jV+V-M0[9X,J@?!E/?|:y,q4wi1(V&xq,pD{#)wT+1u
-Mali,d-q4J~CNW_,6t2d.]&G`X,5?1c-[%F4W,5?1c-[%F4W,d-q4J~CNW_,J>b>D;vQoW,"bt,AY},y$2",P=:bxc_JC&,f?dUt&>$PS
-Mauritania,"jKO,9y0M;#",$/=sir~FxB,#S<rhq}E^A,#S<rhq}E^A,"jKO,9y0M;#",AnTl}_8m=/,"G:w,Y[(aW1",tUW+`.SQo9,p02Yuw`G)/
-Mauritius,skOM(?n$GG,.W=;o.Z5+{,-s<:n-Y4O`,-s<:n-Y4O`,skOM(?n$GG,kC{ALA>P%a,OB*1GftSKF,AX<o!y5NLm,hj]p(iMKl7
-Morocco,mi+kf0LTW.,(UrWRT:M`L,&qqVQS/L4K,&qqVQS/L4K,mi+kf0LTW.,Fx4sZh>`:m,q?uiYsL{dZ,p$AAnTq6oJ,qjZDlzf]=l
-Mozambique,vgdj#X?8dB,;SPVkQB1P[,:oOUjPA0l@,:oOUjPA0l@,vgdj#X?8dB,AX#-0[v2j?,tRCc37FI3F,o0AQQ^2)G6,b^b:}HG<(/
-Namibia,mkgcU7[bA%,(WSO^0D_$D,&sRN]ZC^IC,&sRN]ZC^IC,mkgcU7[bA%,dr(`ZC<V%p,b5~CCSrPP.,t>J`KZclA6,p(q*slFP*F
-Niger,jcu!gLw/&r,$O6jSE8(n-,"#k5iRD7&/,","#k5iRD7&/,",jcu!gLw/&r,bND)UmT$s;,L@{q~To$1C,ds<d0w<UR-,j(X|k-_Sv|
-Nigeria,sB7rZQsR<l,.%g3}J4Ky&,-Jf2|I3J_%,-Jf2|I3J_%,sB7rZQsR<l,g[l><1FFUo,iT>Kc}4kE=,c1(m|]%(&c,P~zp{JVRjt
-Republic of the Congo,u|I}oElaH),":J-K0xX^,G","/f,JZwW]PF","/f,JZwW]PF",u|I}oElaH),sH*CmlNZ<I,L_#MCSsliG,N-%-M=n!dh,lNTL4T}K1)
-Rwanda,"j)i)pB*HJ,",$pUp1uqA.J,#;To0tpzRI,#;To0tpzRI,"j)i)pB*HJ,",Kx0E[9ibDy,M_^<HEN]5=,n8ieJA{+lP,"OlYF5,:|Q3"
-Senegal,t-0>F]bu>P,/t~A*;NnAf,.?}z):Mm{e,.?}z):Mm{e,t-0>F]bu>P,P*^/<)(KjW,uoblR~tJv{,F&@Rc;dl]z,y=oLcr9$cQ
-Seychelles,hrI_uiW>E],!3-G6b`-)V,"9z,F5a_,MU","9z,F5a_,MU",hrI_uiW>E],o-iAF(Oe;d,A#PXVu3{OG,Q+z>Go{V83,L3Z}n~/Szn
-Sierra Leone,uc61ToT%gt,:Ofa]h]6S/,/ke~[g[5o.,/ke~[g[5o.,uc61ToT%gt,oBc!CE4|t8,"J/Z,LIAPP>",J[n$C~*-<~,t&Ov:{KJHy
-South Africa,"e.t$Vi5,>f",7u5l_be$A8,6@4k^ad#{7,6@4k^ad#{7,"e.t$Vi5,>f",BA4?dToa9],"pcq,]2w8O[",.9`Zb?|4],eqi30~lJCU
-Sudan,k/u1:B%DJH,%v6awumw.|,$[5~vtlvR{,$[5~vtlvR{,k/u1:B%DJH,tcsX~cQjI2,CAUBpe+}Rh,"sFwd3<b,Q*",yJ+?5Bb~=:
-Eswatini,e5P*D#I{m{,7e>q(4-?YZ,"6%=p&3,>uY","6%=p&3,>uY",e5P*D#I{m{,Qe#D4C[<+m,pMLZoOPY5w,j!9GChs@cQ,p;W>c.=a5.
-Tanzania,p:SPZ:e/*[,+w[>})Q(qU,*]@=|(P&<T,*]@=|(P&<T,p:SPZ:e/*[,C]<t^C)#CC,K9nrzyH&<X,B{FDr5`ABh,Op1]SnugtV
-Togo,"t+v9b--,qs",/r7iN%t$2.,.=6hM$s#y-,.=6hM$s#y-,"t+v9b--,qs",O1bKEd;`i],mBU4P!~(nj,cXB4#4>X;-,z8UXM/Z23%
-Tunisia,fV`&p81%d(,8_Hn11a6PF,73Gm00~5lE,73Gm00~5lE,fV`&p81%d(,Fx%kVt2%kj,JqECz@.%4i,b&EqNhY[/p,N&=0FE?0K3
-Uganda,"gsS{jR,]|Q",94[IVKs;Jg,8A@HUJr:ff,8A@HUJr:ff,"gsS{jR,]|Q",v8pkKiW5;U,QU|9z>>-i<,G;pW`r5kYU,DnUNQy>V@c
-Sahrawi Arab Democratic Republic,cAlyc~G.y%,5$X!O]+&!D,4IW9N[*%GC,4IW9N[*%GC,cAlyc~G.y%,MfwiBI+|=9,dQpb|V+vI#,QcXm!E@Yw1,p){pPjR5:$
-Zambia,"fxAN),FAc$",89$<p$*tOC,7F#;o#)skB,7F#;o#)skB,"fxAN),FAc$",zWj%QH!y<q,"Et,iKxkLUP",Ef]sAhH-1=,QyZ%*OdzFY
-Zimbabwe,r<N4LAAnnB,-y<d:t$gZ[,",_;c/s#fv@",",_;c/s#fv@",r<N4LAAnnB,E]~7Dc-XV@,e5i.x%JIir,E;nd7c[w(:,Q5Si^%B~:x
-Canary Islands,e?Xq9gy=@[,"7B{2i~!,CU",6|`1h}9+}T,6|`1h}9+}T,e?Xq9gy=@[,iV*VDI/knn,I6q=nh1_(R,d.;lCBC_WK,F+l?rc6nr?
-Afghanistan,"m5j,b/y<EE",(eVsN(!+)_,&%UrM&9*M^,&%UrM&9*M^,"m5j,b/y<EE",K+Rf&9RCYP,L++V2zV3fB,Kg*_Uu;=~F,ubj(k(`p0:
-Bahrain,stRa/S(0$F,.5@MvLoTl`,-B?LuKnS-_,-B?LuKnS-_,stRa/S(0$F,wC(@I#Qj=_,w<=bLWa9^e,D/^OcViV>B,KHEo&Oa7_F
-Bangladesh,l+>Ki!j#v+,&rA/U3V47I,%=z.T2U3DH,%=z.T2U3DH,l+>Ki!j#v+,C%r3!}*o9-,gWiiNVbwTm,dm/G5**HY~,sj6y@z=dRP
-Bhutan,kQ:NIhJy~E,%?w<-a.rL_,"$Yv;,~-qh^","$Yv;,~-qh^",kQ:NIhJy~E,d}n!kX+/ph,KR0|YigF}Y,j/kD7I4;Hg,"vl*,GQz^vQ"
-Brunei,sY>@9w~i^p,.|ACipLbF+,-6zBhoKab*,-6zBhoKab*,sY>@9w~i^p,iR6^@_]dvR,N>!/r-|iKh,E/MT}kv2tI,H_pUK6Xu]`
-China,mJH4kwPF.-,"(.,dWp>yuK",&R+cVo=x@J,&R+cVo=x@J,mJH4kwPF.-,Did1{bE2yj,LBA=S$7TwR,q37^cz*P9W,8CAB|Q`3c
-Cambodia,bW)ch:vs1P,4`pOT)7laf,34oNS(6k9e,34oNS(6k9e,bW)ch:vs1P,k5Zby(Llz+,vAR>ZSEGi/,ioJ7(frmya,"hWSXAL,1[1"
-Indonesia,sx|l+io`B@,.9JXrb0>%T,-FIWqaZ=JS,-FIWqaZ=JS,sx|l+io`B@,z.;^Kjw?w-,i>!/t@^}^?,d8zQ]l>xmo,p?*+RZ<OgX
-India,q2#Yv[O0:|,",bk|7:=Tw0",+!j{6/<S]Z,+!j{6/<S]Z,q2#Yv[O0:|,uq)KM}CVsF,oQe#*&QQB,eswlz&5_-],tJ&;D}C]UV
-Hong Kong,lpbD0St&OU,&1N(~L57=k,%xM&}K46Wj,%xM&}K46Wj,lpbD0St&OU,l_bSqy)=W%,e[XV}qzx6q,L&Wh0Oh!9*,cBQpjb$FFF
-Iran,mbz=7n[0v9,(N#zggDT7z,&j!yffCSDy,&j!yffCSDy,mbz=7n[0v9,P{?pBbVc*#,"qn,8N+7Z^{",M75UjrE!_q,GV|.:pW~=#
-Israel,ijP>aJBT!9,#V>AMC%Mjz,!r=zLB$L+y,!r=zLB$L+y,ijP>aJBT!9,Hb~5J(.Fg~,cdC>T>VY4t,vNlrE-EWLf,LH]h^.GA_i
-Iraq,jI9P-f6r3M,$-i>t}fkcc,#Qh=s|ej#b,#Qh=s|ej#b,jI9P-f6r3M,DE`CrM74%0,"F,ZHHr/u@K",c(O@!xlX|c,z}n.If4:?)
-South Korea,h?a*UKfT_M,!BMq^DRMGc,9|Lp]CQLcb,9|Lp]CQLcb,h?a*UKfT_M,Hfw[5^1FXT,in7S|U&pW],rIn3klxCO3,uU![?ri)d_
-North Korea,r6BV%|..*5,-f%_m@u&qv,",&$^l?t%<u",",&$^l?t%<u",r6BV%|..*5,Cob1W^QJ3F,dm&o}^E:Y%,hs$=I;b%H{,Qmb.+7huoY
-Jordan,i)]+09JUR&,#pEr~2.N@E,!;Dq}1-MZD,!;Dq}1-MZD,i)]+09JUR&,tOc]hT~n}*,g?oII<6[ZM,rBXL[4*?g5,c#-~c^hZ8~
-Japan,l}[BG9.nQS,&KD%+2ug?i,%gC$*1tfYh,%gC$*1tfYh,l}[BG9.nQS,Gg8=;ywiMF,nDcU{JcnF/,m$4os@Y#(Y,if5[hu6l7g
-Lebanon,mtd;>7T|g>,(5PxA0]@SR,&BOwzZ[?oQ,&BOwzZ[?oQ,mtd;>7T|g>,bhv8b|]kY9,eTUA#N*+_%,l::->dQxMA,eDx9dZ&k(k
-Laos,iW>m(L/~c=,#`AYoEv]OQ,!4zXnDu[kP,!4zXnDu[kP,iW>m(L/~c=,juCeYT&eX9,uB1!(|)h6G,l57t^$S&*u,c=F0q+d|m#
-Kyrgyzstan,pkj3RPBUrF,+WVc@I%N3`,*sUb?H$Mz_,*sUb?H$Mz_,pkj3RPBUrF,bTd6E)qj]$,oM2[$i]Jg{,Oy&*?<z%kE,o%$r]1QH{t
-Kuwait,euW0jm=wfR,76`~VfzpRh,6C_}Ueyong,6C_}Ueyong,euW0jm=wfR,Pmp+_CoZ`T,CeFx+%T#{9,g:S=I8r:O>,F5Fbm]10e3
-Myanmar,l*j*EE:!Y?,&qVq)xw3|S,%<Up(wv26R,%<Up(wv26R,l*j*EE:!Y?,dET^[R~4O3,y-F:kD#HUc,s$RMwIQGZb,EKcj[W^+w]
-Mongolia,d3c`&/1Y^D,6cOHn(aRF^,5#NGm&~Qb],5#NGm&~Qb],d3c`&/1Y^D,wOmUda6!>t,"w`Lo,-amU6",Q+8JVQabLR,y!.rR1N]Q%
-Maldives,hXNTVF<:SH,!{<]_yy)[|,95;[^xx(0{,95;[^xx(0{,hXNTVF<:SH,y*>>K_Rv{P,"pR,WF6cJZz","QL%7i$x/c,",FO/D@z0E%#
-Malaysia,"mk20`,N=`=","(Wb~H$<,HQ",&sa}G#;+dP,&sa}G#;+dP,"mk20`,N=`=",Byv;->|tVn,Fvsev/q[3n,Evr|0ju(D2,g^MDw[q&`K
-Oman,eALZe^HCHq,"7$:}Q<,v,,",6I/|P;+uP+,6I/|P;+uP+,eALZe^HCHq,MQbYhy*8W1,OGgJtMdwEP,F@t-f&]i?`,D^z&W{[{ng
-Nepal,l3Ly8PBxt(,&c:!hI%q5F,%#/9gH$pBE,%#/9gH$pBE,l3Ly8PBxt(,j^9KkW@1V^,FeM1Z:8]S-,rqH=>+|p}D,n$0d;K4M?l
-Palestine,g<[f89~U)A,9yDRh2LNp@,8_CQg1KM;?,8_CQg1KM;?,g<[f89~U)A,HxK!=[v%7I,H4;V}Gjc$p,E-hC9K}m$~,eRztGZ?5gt
-Pakistan,iIS#Nw]tr],#-[k<pEm3V,!Q@j;oDlzU,!Q@j;oDlzU,iIS#Nw]tr],j}.YHgP+1),hL96AeDkLm,epu:F7KRn!,"mmXmH,@{!K"
-Qatar,"m{oM,jr>C#",(I0;sc3-&B,"&eZ:rb2,KA","&eZ:rb2,KA","m{oM,jr>C#",h~hx$TrJ9L,d;7/rK:;@r,N<D}v:QnwJ,rVhH@X0hOr
-Saudi Arabia,ln^3p)j3b.,&ZFc19VWNL,%vEb08UVjK,%vEb08UVjK,ln^3p)j3b.,N/[L&}q{Ro,wt1^C^RyMj,jmR])+zhJo,dYQH;whZ9c
-Singapore,cL?8!xP#Wj,5:Bhjq>4`$,4TAgip=34#,4TAgip=34#,cL?8!xP#Wj,s|EEBYpJ*s,K{N|AkKxc*,"qS%*AW?D,f",ya#p*nPn}U
-Syria,e=.VHQ9E+M,"7zu_,Jixrc",6`t^+Ihw=b,6`t^+Ihw=b,e=.VHQ9E+M,cm97y|}K9@,H)jJ?RQ{`4,QPl3$nhmkb,i?;Nx?in:X
-Taiwan,m[96fa+HDS,(DifR^rA(i,&~heQ]qzLh,&~heQ]qzLh,m[96fa+HDS,"uwH,{ZS,Hs",|a&v3R&*G,zE7(j<-d3N,hqHjJQR@ve
-Sri Lanka,g9v~y/;=z(,"9i7L!(x,#F",8*6K9&w+HE,8*6K9&w+HE,g9v~y/;=z(,t/Q9G`l<(*,p*/Yx`XElV,p?N:RJ`9Qb,caoMw/l6Qq
-Tajikistan,g~%pF`(x{u,9Lm1*>oqI:,8hl0)=npe/,8hl0)=npe/,g~%pF`(x{u,"v0.(wt0=5,",yJuwsoHp0*,m@%Rs{o2LO,qvU`=w(275
-Thailand,"hE5j*e,Q?[",!)eVq|sJBU,9MdUp{rI|T,9MdUp{rI|T,"hE5j*e,Q?[",lJGFm$U&>?,r[B4}qKEKl,O|]ivh~%v{,oVtF.y]H)M
-East Timor,fRSM{K+;[w,8@[;IDr*D<,7Z@:HCq)~;,7Z@:HCq)~;,fRSM{K+;[w,uWjhG1h]m,de.tDgRhFi,bq]dHo&Tn~,x2Ho#9JF2&
-United Arab Emirates,o~}KVA:VbI,*LK/_twON},)hJ.^svNj|,)hJ.^svNj|,o~}KVA:VbI,BAz%}9{UE,"AFNn,$>?6v","J)9J,MA_jm",njbrSU^agd
-Turkmenistan,u-`cspdp)D,:tHO4iPip^,/?GN3hOh;],/?GN3hOh;],u-`cspdp)D,hM~h4Ec9ZW,QF&bT0`se),Iva{=NlZof,uRPZ]lF~NL
-Yemen,"e42BpV,P}C",7db%1OsIK],6$a$0NrHg[,6$a$0NrHg[,"e42BpV,P}C","x(aw,hH&Y[",w_RRz<D>=p,MXc[U*Dc|y,o@l9/@&CEQ
-Vietnam,pD<Pd$Ag@J,+(y>P5$~C~,*Lx=O4#}}},*Lx=O4#}}},pD<Pd$Ag@J,zybU=+SV=e,rE0yeh1k~6,xCFE#ual.E,I4?0i2<YxI
-Uzbekistan,mbGXc0y3Pe,(N+{OT!W>7,&j*`NS9VX6,&j*`NS9VX6,mbGXc0y3Pe,jD9{n{|+PU,ndb6k{nIX-,O.[B3&pjNc,JA;WxR7VVZ
-Fiji,gB|K:+r?1V,9%J/w#3.al,8JI.v!2-9k,8JI.v!2-9k,gB|K:+r?1V,s|eW&jr[=w,gVIrkH[g_z,w_*e?Ms1]_,ncoVNK:5c/
-Papua New Guinea,lhWI;$JC9(,&T`-x5.viF,"%p_,w4-u*E","%p_,w4-u*E",lhWI;$JC9(,CQy8.z2s`v,tLN$~<D&LN,kQ8x(01<},B*Q><ygyqQ
-Australia,k0{O[6l]bH,%~I=DZX;N|,$8H<CYW:j{,$8H<CYW:j{,k0{O[6l]bH,"LYe,4PfG4a",M$Ym*hq(lZ,Owoj&4yEcQ,Pc}I71FH$K
-Solomon Islands,"r>g<|,FWi%",-ASyJ$*PUD,",{RxI#)OqC",",{RxI#)OqC","r>g<|,FWi%",Rh_*(xz;/],iqg6(sCS87,A7d`$VleNv,Ko1^yAR.yn
-Argentina,n&>e`2FO/S,)nAQHV*Hvi,(/zPGU)G[h,(/zPGU)G[h,n&>e`2FO/S,jDvPRSN7UT,E_Y_gka<wh,sUW(K@)rpu,l{J_M.Vp>X
-Bolivia,khB~(m^@Z5,%T%LofF/}v,$p$KneE.7u,$p$KneE.7u,khB~(m^@Z5,hnq?l@KUUT,xBZF?3m:=u,K1#2~5/6~Z,LCs2:t<[-X
-Brazil,spKoFRM4if,.1/0*K;XU8,-x.Z)J:Wq7,-x.Z)J:Wq7,spKoFRM4if,sLc+1O/t|!,yR{s}{|vzP,L#b;#eu1UR,c@58oWbN3U
-Chile,q8][)Ri}=q,",hEDpKU[z,",+)DCoJT@`+,+)DCoJT@`+,q8][)Ri}=q,m|F4][J.!m,bD5Cj?{})5,BHe5zlq%zC,N@bHVDe+Kb
-Colombia,hoHandbYAy,"!0,MZ{NR$>",9w+LY`MQI=,9w+LY`MQI=,hoHandbYAy,L>tNacmJP#,cD]Q9Pd0ZO,Ca[)+1M+q?,heo$u3%xYs
-Ecuador,lmRujD!(A7,&Y@6Vwj8$x,%u?5Uvi7Iw,%u?5Uvi7Iw,lmRujD!(A7,wX.mVG|9{n,F289Jx}!aE,CTD4|lJ}]5,Q8=#jf;Izu
-Guyana,q:XyGf#>Wg,",w{!+}k-`9","+]`9*|j,48","+]`9*|j,48",q:XyGf#>Wg,c#$?0jnW0K,J(!?!{vv{7,"oA1,v5>^){",O>(c0%czoO
-Paraguay,s#:aIK$9^x,.kwM-Dl2F=,"-,vL,Ck1b<","-,vL,Ck1b<",s#:aIK$9^x,g-3%G(QyEf,Ci{2x]j^h=,A$m)oTJ1BW,m%N$gpC+n]
-Peru,jBd@A?>g|},$%PC$.A~J1,#JOB#-z}f0,#JOB#-z}f0,jBd@A?>g|},za4sz~iaR*,I`2u4=)$rI,jxR[;SimkU,rJG$qf|FO4
-Suriname,koI(}OyJ:@,%0-oKH!CwT,"$w,nJG9B]S","$w,nJG9B]S",koI(}OyJ:@,A}fIE>Pq[I,n+6|^+yndU,lR`ZpmCTOP,DOTLV^*F{H
-Uruguay,e?gIaPc$Ox,7BS-MIO5==,"6|R,LHN4W<","6|R,LHN4W<",e?gIaPc$Ox,FqClN*Uskm,A^v{U|AR{a,p/fH$J091^,fk0sh|Ih~P
-Venezuela,o#&RMA_REo,*kn@;tGK)*,"),m?:sFJM)","),m?:sFJM)",o#&RMA_REo,vqczM!*!WR,p7}c5wf.O#,OwHb{Mz|$h,"w7J5,@!ZO`"
-Cook Islands,s4E?ZF[E<>,.d)B}yDxyR,-$(A|xCw_Q,-$(A|xCw_Q,s4E?ZF[E<>,dL;ASbD>B},!lbQb6Q:w,h<Q}<=6jye,Q@3rl@WPXz
-Federated States of Micronesia,k1]FH+s8j@,"%aE*,#41VT",$9D)+!30rS,$9D)+!30rS,k1]FH+s8j@,B>y*UU741f,"jH,I*;o6vh",r@_hV$i3&g,A`?%3b$nUX
-Guam,dWA49p}F{k,6`$diiKyI%,54#chhJxe$,54#chhJxe$,dWA49p}F{k,b<l<9Sv>;o,G2WhVSEk&4,vRx60WZhA6,O%#xYWz^#M
-Vanuatu,K*b}<I3(~,Dq41y-co],"C<30_,bn[","C<30_,bn[",K*b}<I3(~,MfdunrN!.(,y&XDZ^<U3_,Q_m!=Xe)uk,fwm<gn03ey
-Canada,e?h=Xhs+K&,7BTz{a4#/E,6|Sy`~3!SD,6|Sy`~3!SD,e?h=Xhs+K&,C@Qb!4TM+Y,dMQkP!;0c=,vp8J2mcIv`,HzN{~)3NGK
-United States of America,b@M[XTc?}5,4C;D{MO.Kv,3}:C`LN-gu,3}:C`LN-gu,b@M[XTc?}5,hV^z0k.t6x,"L?:>A,WJLB",K[7:%jDicU,OzZ|9/zKGy
-Mexico,sxOMs+bE8@,.9=;4#NxhT,-F<:3!Mw)S,-F<:3!Mw)S,sxOMs+bE8@,vFrU{gPXOA,nNI(>d`5|I,qj/S4:J~Wh,J+O2qUIUz|
-Puerto Rico,t3aZXtpNyi,/cM}{m1G!#,.#L|`l0FG!,.#L|`l0FG!,t3aZXtpNyi,^@~8x/eFp,Pkxoj6=pZF,c+d=6X;DR:,"OX,mUDIStL"
-Cuba,rPekx@n9:L,->QW9/Z2wb,",XPV8.Y1]a",",XPV8.Y1]a",rPekx@n9:L,K4#|XaqO:g,rz5xk#1<PP,xm[hZ@]0D2,"kjo~PAZ.,y"
-Dominican Republic,lAxH.CfJB@,"&$9,uvRC%T",%I8+tuQBJS,%I8+tuQBJS,lAxH.CfJB@,"stl,m~cAO&",xxk(Bq-Z`<,cl`b5<!_&X,r#k4%<ieJ;
-Haiti,hZ/V/D&rO`,!}v_vwnk=Y,97u^uvmjWX,97u^uvmjWX,hZ/V/D&rO`,"j1e,tg|Z&b",ewx9/IV5o%,z@fLLI>[@B,k^PtQpRdLQ
-Jamaica,h&`>n98~V1,!nHAZ2h]_r,9/GzY1g[3q,9/GzY1g[3q,h&`>n98~V1,qjIBt_WC^1,xddNP~dyT_,Ob.MR2u/-&,i7sQICmsKP
-Trinidad and Tobago,t50y/[AEhF,/e~!v:$xT`,.%}9u/#wp_,.%}9u/#wp_,t50y/[AEhF,FQm}Y9aG^*,zRmOT{Xeqm,oO/>jPN^a5,I=mZ*3?!_l
-Bermuda,gBCR?!O*;E,9%&@B3=!x_,8J%?A2<9^^,8J%?A2<9^^,gBCR?!O*;E,h:@GWL?4y1,H+Rb-3u-sn,JM7]2EJ[qX,wY{he1D;Tc
-Guadeloupe,tTnCoO/*tk,/]Z&0Hv!5%,.1Y%ZGu9B$,.1Y%ZGu9B$,tTnCoO/*tk,KI?g-vLTJ8,LE9jC#sSOE,jpDvwSb-OL,Qg3C+rbaa*
-The Bahamas,W5?6yQZD2,PeSw!?}(V,O%RvG>|&U,O%RvG>|&U,W5?6yQZD2,"d`,;^d_nt5",N}PXRbob?8,J%7U=$j(Cr,Bp:8AxZIJ*
-Barbados,e{e8vi@^PY,7IQh7bC<>o,6ePg6aB;Xn,6ePg6aB;Xn,e{e8vi@^PY,b:(mUH@(`.,il|4oTIh7t,q;6Wv3u)tx,O8La>q*+=D
-Belize,tcneuK7v%`,/OZQ6DgomY,.kYP5Cfn.X,.kYP5Cfn.X,tcneuK7v%`,c0H>DK:hY.,J2r:;Tb}bM,"D@,Q^H)}Ln",d&bsqV:N$w
-Costa Rica,uH*Q(mcRt5,":,q?ofOK5v",/Pp>neNJBu,/Pp>neNJBu,uH*Q(mcRt5,"CPWU&xD,31",iT]9Jy+|:B,ebcMj4pw`P,ELV(4@XqZt
-El Salvador,k$1_yaF?9#,%laG!^*.iB,$-~F9])-*A,$-~F9])-*A,k$1_yaF?9#,Aq@4iLUo[t,ns9RF=A{<?,lWXANkm_ks,gM!|AcSE~W
-Guatemala,dUZ^=SE5BG,6^}FzL)Y%{,52|EyK(XJ`,52|EyK(XJ`,dUZ^=SE5BG,u2@(1}y4a{,oQW|#KNZR!,f.SoIgVf$q,^(x:orV#n
-Honduras,t_h*fbN#:(,/GTqR_<4wF,.cSpQ^;3]E,.cSpQ^;3]E,t_h*fbN#:(,u2YZ8>C2[I,QUEZaS<.i&,sHKG^]G1Hi,Leo~hD<WPr
-Nicaragua,q=w[<m2Bk&,",z8DyfbuWE",+`7CxeatsD,+`7CxeatsD,q=w[<m2Bk&,B1cUA{Hro^,NgMbQSn4l{,xPbky$#R*1,"iKL]@oe;,B"
-Panama,vpOTK6tMr@,;1=]/Z5F3T,:x<[.Y4EzS,:x<[.Y4EzS,vpOTK6tMr@,b~C@$BV@fk,v5e#_P()cc,gw%[JT~eOZ,QIn7X6P~>i
-Antigua and Barbuda,m2F|cUkKhv,(b*JONWDT;,&!)INMVCp:,&!)INMVCp:,m2F|cUkKhv,ddf7bzEG~m,J2R`q[Z2!i,o@zxjV_qcp,qvhov1fh!t
-Dominica,k}4/oj#$~s,%Kdv0ck5L.,$gcuZbj4h-,$gcuZbj4h-,k}4/oj#$~s,"P,t][$~Axv",DMfp:u>1/~,K~OD+`QJa(,P?8;T>jkXg
-Saint Vincent and the Grenadines,va/ky=f5pK,";MvW!,RY1a",:iuV9+QXx~,:iuV9+QXx~,va/ky=f5pK,xN@x`d<BS1,E{q^42h($(,nm*l%S8r+{,fGB0mK7OmU
-Somalia,"c,5(mUGzYT",5seoYN+s|j,4>dnXM*r6i,4>dnXM*r6i,"c,5(mUGzYT",j.J_!d]H{c,N&H{fk[c3L,o^IIsTJR4[,b.K2|uT9#&
-Zanzibar,gp[h@]y13l,91DTC;!Uc&,8xCSB:9T#%,8xCSB:9T#%,gp[h@]y13l,nLS!c^B.u5,yTwB:d{m;m,uc9G:E._YR,o6Q=4QRc:P
-Ghana,gx:;za!?C9,99wx#^j.&z,8Fvw!]i-Ky,8Fvw!]i-Ky,gx:;za!?C9,uJWy?`0JRW,j[3-~lc=uu,/zj4yGq-~,O6XK(yEdjN
-Guinea,r]*Ioa%$bK,-Eq-0^m5Na,",ap,Z]l4j~",",ap,Z]l4j~",r]*Ioa%$bK,I[3;:2u9!5,"E+q[fM~I%,",zlk#[1bx]e,Q!&RwY_+~G
-New Zealand,)Y}Qy.3GK,9|1g!uc+D,860fGtb*C,860fGtb*C,)Y}Qy.3GK,Qt?NY}jsN;,Fa.~5.=<;F,tBCiVBcuG_,HU{V)h>->1
-French Polynesia,lH^2D]w;[H,"&,Fb(;8*D|",%PEa&:7)~{,%PEa&:7)~{,lH^2D]w;[H,m~5*]PDD9k,qjeAhS!PI:,lI<3M8p[+),|:r0wYpo+
-Philippines,qx%>fB$d+$,",9mARul{rC",+FlzQtk`=B,+FlzQtk`=B,qx%>fB$d+$,vlkjlV^U~T,m6|Qi!lWAQ,n58X<QI]0p,"M<c,]nB<a~"
-Kosovo,libliptkB4,&UNXUi5d%u,%qMWTh4cJt,%qMWTh4cJt,libliptkB4,bwsw8$TgX1,lq[V&Ro6p!,"rs3Uv}D,)h",N={U.qMDd5
-Libya,jrM28*HbyG,"$3;bh!,_!{",#z:ag9+^G`,#z:ag9+^G`,jrM28*HbyG,d[tm>aNv-o,uCA#@hm#=u,jcwmr?mk}z,OgRSGzP9iU
-Palau,r?E$4f-d0/,-B)ld}t{~M,",|(kc|s`8L",",|(kc|s`8L",r?E$4f-d0/,fPO>]fFure,u~Z*V|m1JC,Abp+=0%|oz,gux9;qM)nK
-Saint Lucia,leh^fmrt*#,&QTFRf3mqB,%mSEQe2l<A,%mSEQe2l<A,leh^fmrt*#,oBs%LSd4B;,Aovq2LfJ3x,B2:MgtMw1@,hq?[{n24G;
-Bali,O~pXkAbd3,HL+nW$NPW,Gh*ms#MOV,Gh*ms#MOV,O~pXkAbd3,IxLAH)+-_V,J?N4X)hLQ4,llB|P7o^Tq,u._5@pRbGb
-Grenada,f*LO~>!0PN,8q:=L-jT>d,"7</<K,iSXc","7</<K,iSXc",f*LO~>!0PN,"l[/(,BJdiJ",t2BlE6w@U0,K7t:ah)Nlf,t1sE<.qtO/
-British Virgin Islands,q[}7hk(+=e,",DKgTdo#z7",+~JfScn!`6,+~JfScn!`6,q[}7hk(+=e,k`{m~8Eb`.,mmn-72S%.C,"n1HR1,WDIm",t|}7%V0{4w
-Turks and Caicos Islands,q7do-wLx%E,",gP0tp:qm_",+(OZso/p.^,+(OZso/p.^,q7do-wLx%E,GJT]wWpqv6,iBkK=.H[[*,cx%FD8~SUL,v?vAk$tZAa
-Cayman Islands,vwc3}.=Z#&,;8OcK&zSkE,":ENbJ%yR,D",":ENbJ%yR,D",vwc3}.=Z#&,"OL?i,z)TP#",yD<PlLql`:,M=3y(}U;7v,"l,[F>UJ/PN"
-Anguilla,e<X;[vACXC,7y{xDo$v{],6_`wCn#u5[,6_`wCn#u5[,e<X;[vACXC,rsxD)TXKC#,i4D*V-sHYX,rMX~]}XH:Z,zz4Ej5gtx6
-Azores,"j=L,YBvsBk",$z:s|u7l%%,#`/r{t6kJ$,#`/r{t6kJ$,"j=L,YBvsBk",tKD)*8S3TN,NLQ8Se/(B%,tTWNp2kfJh,BJvzz<mQn/
-Curaçao,oa87&PB&Bm,*MhgnI%7%(,)igfmH$6J&,)igfmH$6J&,oa87&PB&Bm,y9[[$e%qC`,dl?k9`s(|K,bPqp-AGH3Y,GH~LmtD8o#
-French Guiana,b^Try&me1A,4F]3!7Y|a@,3b[296X{9?,3b[296X{9?,b^Try&me1A,t6K(T;};3},zR_=AM#e1.,iEf6;Pr<M!,N@2CXFim}.
-Gibraltar,o``:?0>/yz,*HHwBTA(!?,)dGvASz&G>,)dGvASz&G>,o``:?0>/yz,"sg,bj=%n1w","M~5K,Lq-LX",AfMgn:9E6@,jZpi[+b>`2
-Guernsey,pz(G*<F93/,+#o+q+*2cM,*Hn*p*)1#L,*Hn*p*)1#L,pz(G*<F93/,onvgK4ynAq,sKVdix$DBJ,y;=#m2VTao,LvKjC9)Jop
-Isle of Man,cV4idO^r8W,5_dUPHFkhm,43cTOGEj)l,43cTOGEj)l,cV4idO^r8W,r]11B;H~[z,emf@Kw7U_W,LB())=5`]S,f&H7U0-[5}
-Jersey,m*PYE=#wr^,"(q>|),kp3W",&<={(+jozV,&<={(+jozV,m*PYE=#wr^,"CO+b,zPO_I",j{s4{ed!RV,J0UNSJ4UR.,MD>R`2$IfI
-Kiribati,sXzvT.g31p,.{#7]&SWa+,-5!6[%RV9*,-5!6[%RV9*,sXzvT.g31p,NwEo@VHs_d,q|wSo|9[WL,Nvp;D=X.u{,kA<Bx%0-hP
-Macau,mq)8`hi{hb,(2phHaU?T4,&yogG~T>p3,&yogG~T>p3,mq)8`hi{hb,vwc}tXrF=w,o.R(%XRfF<,"p{:,t++CFI",kp&`?`CDeL
-Madeira,h}lnSN_f$_,!KXZ[GG}lX,9gWY@FF|-W,9gWY@FF|-W,h}lnSN_f$_,"H,;72`%LJX",J4U9*&@eJO,CpG.*qzHU5,yp(op%kwx]
-Marshall Islands,"eT<gzg?q,r",7]yS#~Bjs-,"61xR!}Ai>,","61xR!}Ai>,","eT<gzg?q,r",hO~G0Ujd_$,x$e/?}ioiX,"fO#rmj#,Uh",gum46?fIJ@
-Nauru,vE[T$`n9T),;)D]l>Z2]G,:MC[k=Y11F,:MC[k=Y11F,vE[T$`n9T),D|=[nt0eT&,"O,{dn7CExu",r=<RFKhs~w,nB97`B-u)
-New Caledonia,tj&bK}%P!F,/VnN/[mIj`,.rmM.@lH+_,.rmM.@lH+_,tj&bK}%P!F,vLL9vrH]jE,vqizD*x9.v,bit-NvK^B3,O-wR/1*Y6i
-Niue,kX]hN=_.c-,"%{ET<,G&OK",$5DS;+F%kJ,$5DS;+F%kJ,kX]hN=_.c-,G5M^3c_/X|,AE%P6;/:4z,"I>,%[aL/r)",M1DF:M)y_T
-Northern Cyprus,"r/B|ra%L,.",-v%J3^mEsL,",[$I2]lD>K",",[$I2]lD>K","r/B|ra%L,.",bbW|f)4_>u,i;wkVQEC8~,"q,5sUDZJ@|",H!Ms:!^6Ka
-Saint Kitts and Nevis,b[(2`4t&?J,4DobHX57B~,3~naGW46|},3~naGW46|},b[(2`4t&?J,QP7}%SW/px,w^9U1RGI}b,"fN1A,qu<xJ",P$;>yK&Bb#
-Samoa,qvITjNxkLN,",7-]VG9d:d","+D,[UF8cTc","+D,[UF8cTc",qvITjNxkLN,h70gtJ%&xI,Nq3Z?3&|oE,A16VT}*wpu,"NJhO,P|nW`"
-Somaliland,jX=#G8wu#(,${zk+18nkF,"#5yj*07m,E","#5yj*07m,E",jX=#G8wu#(,sOvum<h.&0,Dy8wkcY4!S,Ip12e4sGC?,ki}T;HSiij
-South Sudan,l&#7I)Ah/E,&nkg-9$av_,"%/jf,8#~[^","%/jf,8#~[^",l&#7I)Ah/E,"p2,K;bOB~T",pHNtJdHo[e,mxqXkoW;I],":+A,]QJt-"
-Tuvalu,"de=9c:,@j9",6QziO)s/Vz,5myhN(r.ry,5myhN(r.ry,"de=9c:,@j9",e_%R[08+Z,IBl:CrljZo,BND}O4g5Z(,o6f7z~ZCr6
-United States Virgin Islands,kE!iKHLN_g,%)jU/A:GG9,$MiT.z/Fc8,$MiT.z/Fc8,kE!iKHLN_g,pSK9uw6xC?,EwR<30)#1g,p~cba36}ll,jX.V=Tm<P3
-Åland Islands,d``B*6:eCx,6HH%qZw|&=,5dG$pYv{K<,5dG$pYv{K<,d``B*6:eCx,s{g7@QD$qr,ikT)0#7&yt,kZ;onU6NiN,eItZ|YXm$3
-South Ossetia,p]t8:Tka7q,"+E5hwMW^g,",*a4gvLV](+,*a4gvLV](+,p]t8:Tka7q,jhuwlGqRkR,kAP^Ny~90T,oI5~{W$B0+,f*vz&Ph[bR
-American Samoa,niJUFZF$Y:,)U.^*S*5|N,(q-])R)46M,(q-])R)46M,niJUFZF$Y:,cfXokA*89x,"u.[N1#,@y:","G.,g9N->(r",fsloLaTPf8
-Northern Mariana Islands,p}Qa|!7PpR,+K?MJ3gI1h,*g>LI2fHxg,*g>LI2fHxg,p}Qa|!7PpR,t0QR1Q:HMY,xDK0`i2s%/,fITQ3o(eNJ,ga-I(hwLN)
-Aruba,uv1fGXHN@),":7aR+Q,GCG",/D~Q*P+F}F,/D~Q*P+F}F,uv1fGXHN@),"e[{g,ks$!I",t9Ryk}`qj2,"vu]t,+fglW",AUgq3IkilN
-Abkhazia,sRw-ik:I$v,.@8tUdwBl;,-Z7sTcvA-:,-Z7sTcvA-:,sRw-ik:I$v,v6t>$<ADP[,PB_{Euk>>/,MZ+&Gti2z$,"w`;zj+qi],"
-Sint Maarten,bnEK#)[;qT,4Z)/k9D*2j,3v(.j8C)yi,3v(.j8C)yi,bnEK#)[;qT,i:L[HB&@F[,A)h(R4;N+m,Cr+mEZlgA:,Ar:~TK>ugF
-Republic of Artsakh,ey:Q|*t!Lg,7!w?J!53:9,6Gv>I942T8,6Gv>I942T8,ey:Q|*t!Lg,x]o%O2Wi4u,vPy3m1oa#d,AYOdHe0+qw,pbJ|E`wn_~
-Tonga,"c^,~EC6Pb2",5FsL)vfINs,4brK(ueHjr,4brK(ueHjr,"c^,~EC6Pb2",ebha1T}R8+,d`zDA9y~gZ,J^vx<Yy&b%,"KG~t}M~,_o"
-Transnistria,tMMtBUpb$&,/;;5%N1_lE,.U:4$M0^-D,.U:4$M0^-D,tMMtBUpb$&,CP|Bi<B+3(,C&k%h=UUn#,Qm?>e]Q]ag,|*Z`50Bgs
-Sardinia,jKIDq|}J&c,$/-(2@KCn5,"#S,&1?JB/4","#S,&1?JB/4",jKIDq|}J&c,"i9-RjgM[_,","dzu,L2RTO6","CH0T!),h9{",qW1*i(&R3$
-Kaliningrad Oblast,dC:e5G4J/p,6&wQezdCv+,5KvPdycB[*,5KvPdycB[*,dC:e5G4J/p,x`*~=TA+FK,CQXXs$n5cv,r+ehJ?q]D.,iZ`BoOu7TH
-Martinique,u;|vR#mVMW,:xJ7@4YO;m,/^I6?3XNUl,/^I6?3XNUl,u;|vR#mVMW,bmb^QU~Z*k,xBC@m/Re-7,F[Xrq2xy>E,B=^Q!Oy7dx
-Java,gDsLPj(9S#,9(4:>co2[B,8L3/=bn10A,8L3/=bn10A,gDsLPj(9S#,P&j>MnZjBl,u~.<cG1`ob,A1z!_C=d(c,EykZ%2$zVY
-Corsica,xb&P*pH(Q,"qNEfq1,oJ",pjDe<0+nI,pjDe<0+nI,xb&P*pH(Q,FUCfa4kb<y,"B[,~m31[Og",HedPV<oAW~,P)2eJ7Sr]e
-European Union,Bszsaz0Iuo,[4#4Ms~B6*,@A!3Lr}AC),@A!3Lr}AC),Bszsaz0Iuo,q9GttqBN(j,dIUwggycz7,FlmNG3Av;e,"Cj.2Qz[,?;"
-Gulf of Mexico,JOT:U4ayh@,~=]w^XMrTT,}W[v]WLqpS,}W[v]WLqpS,JOT:U4ayh@,ujWW0n-WqL,fBT#}$9v{@,zy#+XVV9S`,mjltS8qw#I
-Philippine Sea,G/^_##fcPN,{vFGk4R`>d,`[EFj3Q_Xc,`[EFj3Q_Xc,G/^_##fcPN,u}sPj7cerL,uvRyF*9Zqg,DjNpq@BAMv,wN+#PV27nX
-Southern Ocean,LPF4AfaHKR,b>*d$}MA/h,aX)c#|LzSg,aX)c#|LzSg,LPF4AfaHKR,Fs>y5(sRng,s^4z/0k+AF,jVChM/v;]D,DMw7[z1|/f
-Gulf of Thailand,rSneU!3}bn,-[ZQ^3c[N),",0YP]2b@j(",",0YP]2b@j(",rSneU!3}bn,c!B%9S]zNK,Ej./VrJYpS,u@^{[]68&M,myDYy<t!DY
-Micronesia,cv+Nq9:a<P,57r<22w^yf,4Dq;11v]_e,4Dq;11v]_e,cv+Nq9:a<P,gH(-5bzcUq,"Og]Pyc,dB|","q,Yx(B^2)]",e7aUv]y3NG
-Pacific Ocean,f*2@qiHh_1,"8qbC2b,aGr",7<aB1a+~cq,7<aB1a+~cq,f*2@qiHh_1,"g.N+uMm,{6",O6aT:6ldHZ,o2AxTxOe+;,fL<u4=Axl[
-Atlantic Ocean,nuU8A_$i2M,)6^h$=lbbc,(C]g#<ka!b,(C]g#<ka!b,nuU8A_$i2M,IS`eM7]t)I,xWSI:FF;%x,"e1k,rPrJXi",j65XMZPPCl
-Indian Ocean,fT!w8R#>dg,8]j8hKk-P9,"71i7gJj,l8","71i7gJj,l8",fT!w8R#>dg,Ja&@${-ll#,EMPCtOx;Rj,fezBXMIU#+,taGg_[({a>
-Arctic Ocean,gG6SWfM>H0,"9+f[`};-,q","8Oe@_|:,Pp","8Oe@_|:,Pp",gG6SWfM>H0,f#ZCPMD62V,yXRb0bi*D.,ygzZMO52<5,"c3_S$ge,H%"
-Hudson Bay,sM0GPt1HS1,.;~+>maA[r,-U}*=l~z0q,-U}*=l~z0q,sM0GPt1HS1,I_$^q=J15;,"c3fq*,<:~U",RiU6/6cNcj,mVqJCtNO^w
-Labrador Sea,dlU7VG|3Gd,6X^g_zJW+6,5t]f^yIVO5,5t]f^yIVO5,dlU7VG|3Gd,"O_++P3q,lg",D#f:CN7HH4,EV{1>IbA3.,f*A:Z4bkRD
-White Sea,cEO^y)Md[G,5)=F!9;{D{,4M<E98:`~`,4M<E98:`~`,cEO^y)Md[G,yKo`$PaHGg,ym)YXCoojW,Ok!(($u.|p,ite]=1-[IW
-Denmark Strait,eN#^kPGv*L,7<kFWI+oqb,6VjEVH*n<a,6VjEVH*n<a,eN#^kPGv*L,J9k3i5aRzz,"n!%,$ZZU.A",suwt).}j(N,sE1}%6$3D9
-Norwegian Sea,lp@e##m.!+,&1CQk4Y&jI,%xBPj3X%+H,%xBPj3X%+H,lp@e##m.!+,F9A3Lkp?+N,ds)Lw5L_oG,LoxeR.`jw@,li{q-g0Ru|
-Baltic Sea,epvt3>HH?U,"7175c-,ABk","6x64b,+z|j","6x64b,+z|j",epvt3>HH?U,v]C@D/(-+g,Btv`iTH0LW,p}2F6mZ.QA,iWh/XzA:Fx
-Celtic Sea,E3u*2.<9#`,_c6qb&y2kY,"^#5pa%x1,X","^#5pa%x1,X",E3u*2.<9#`,kn6vhJtt!Y,q]o/<>5}wu,bEhl$M2clS,QQ+*SW>?NN
-English Channel,q1Q3Do8S>g,",a?c(hhLA9",+9>b&ggK{8,+9>b&ggK{8,q1Q3Do8S>g,nlr&VdfBJA,M_Aq-@$=Ed,mUci[@*L<c,J{(N4{^e:N
-Adriatic Sea,yX:tmrd5;],>{w5YkPYxV,=5v4XjOX^U,=5v4XjOX^U,yX:tmrd5;],BLvM|PE:rh,M0{EnlSZ[&,CQTeWe?;Y/,GZ2yh|R:fR
-Bay of Biscay,H*c[ML+`s=,|qOD;Er>4Q,{<NC:Dq=AP,{<NC:Dq=AP,H*c[ML+`s=,f.Z<UFi.{x,q}Pw=WLDWu,Ih-lfoAUWi,gx#n~i)Kft
-Black Sea,e_;dzXj8de,7GxP#QV1P7,6cwO!PU0l6,6cwO!PU0l6,e_;dzXj8de,wsM3JR2Xv?,od6cw^-E-],txn5MPFzv#,"sB,_Fhn5&I"
-Aegean Sea,iB-8Br~onq,"#%th%kLhZ,",!Jsg$jKgv+,!Jsg$jKgv+,iB-8Br~onq,G4|N9mDxa&,Ily]WmR8_^,*/b5m[q8j,xV<kEl1ZJ$
-Balkan Peninsula,zSc]-^U=0=,"?[OEt<^,~Q",>0NDs;]+8P,>0NDs;]+8P,zSc]-^U=0=,l1uc5E8j;X,hpvj)-!USf,eY!@E#<EI8,lGG8WbUQzc
-Caspian Sea,x2d4n4ADcP,=bPdZX$wOf,<!OcYW#vke,<!OcYW#vke,x2d4n4ADcP,Rf#Y$PY2hD,J3~et+v|e@,cH2i]a9RGb,p6lxT;d^Pq
-Mediterranean Sea,Gn;q2Y)Xe4,{Zx2bRpQQu,`vw1aQoPmt,`vw1aQoPmt,Gn;q2Y)Xe4,x18Y%w8iOt,G!-:Hml<-@,McX+ixO5W@,ngPe&f4ARW
-East Siberian Sea,gRVZ]qJ#>O,9@_}Ej.4Ae,8Z^|Di-3{d,8Z^|Di-3{d,gRVZ]qJ#>O,pvm.S00zT/,f-#kZAo/ON,I+N4^}Lq%;,ywSb;Oor?l
-Bering Strait,"J%,fuysl*&",~msR6r4eqE,}.rQ5q3d<D,}.rQ5q3d<D,"J%,fuysl*&",AnHKmxdHRZ,etM=#0^o-o,M#?I9kQFyj,uxU}LMXAY+
-Arabian Sea,r(h9&#wc~B,-oTin48`L[,",:Shm37_h@",",:Shm37_h@",r(h9&#wc~B,h:!&t0Lvqc,i-&Ri-vDye,s$aq*|$f>s,z;zuT%S.hs
-Red Sea,_]DH+g9!$,=E^|rSij5,<a]{=Rhi4,<a]{=Rhi4,_]DH+g9!$,urEGY*T)mW,JS=q2$2L3],mJVG+OU2XO,g*C+;[^vP9
-Dead Sea,B:x<p&Q=t),"[w9y17?,5G",@]8x06>+BF,@]8x06>+BF,B:x<p&Q=t),d9jaR(A9o(,"D,@m:}o|sK",KNRlqLN%1t,"gn,]{C-kDK"
-Bay of Bengal,z:*d{z(~V2,?wqPIso]_s,>]pOHrn[3r,>]pOHrn[3r,z:*d{z(~V2,c2(xx0>{|K,fs]5;0c;}B,ngbe6iK.Qu,x-s/YndH;0
-Sea of Japan,"d}R:qHj1,7",6K@w2AVUsx,5g?v1zUT>w,5g?v1zUT>w,"d}R:qHj1,7",nsv]+(L(N^,t$C>63YEjQ,q3=L7rObtd,pG~&s-.Pv=
-Yellow Sea,L5M1*yG7eH,be;aqr+0Q|,a%:~pq*Zm{,a%:~pq*Zm{,L5M1*yG7eH,bQ*]^-KLDC,EZvlR:83-^,J#7Tt[f!e*,iw)&(><6ju
-Coral Sea,"s|K&2S,UP|",.J/nbLsN>0,-f.maKrMXZ,-f.maKrMXZ,"s|K&2S,UP|",mH(F;!A-^i,MHvNbPV}Qa,B8UUt(OH@c,HeX)uooi/y
-South China Sea,t$y1C2R-Av,/l!a&V@%$;,.-9~%U?$I:,.-9~%U?$I:,t$y1C2R-Av,gs<Y_*zj#^,Hmbq~BF@]H,pediB(:-]T,x*o*2(qrzU
-Tasman Sea,eHJ?)TAdTo,"7,.BpM${]*",6P-AoL#`1),6P-AoL#`1),eHJ?)TAdTo,fL<HB36|&),v]|R(og)1x,oQ(1eJZ%h_,d/vX5sh?Z9
-Gulf of Carpentaria,pQpX%(EVOH,+?1{m8)O=|,*Y0`l7(NW{,*Y0`l7(NW{,pQpX%(EVOH,kI#F9[@KH|,yB!Y:vm[{l,Kroi)OhVu,G&{G$z2N`]
-Aral Sea,qiv/4tOlf=,",U7vdm=eRQ",+q6ucl<dnP,+q6ucl<dnP,qiv/4tOlf=,k~[RV@<s7/,IW*fIQ@Vn!,M?CI|U:7E,cd@bD^dpRt
-Persian Gulf,M$bc0[jYf0,clNO~:VRRq,b-MN}/UQnp,b-MN}/UQnp,M$bc0[jYf0,Ngx+p%Tn$u,v:EM)mKjX1,p><!jX(|}?,B4o4Qgpxa=
-Caribbean Sea,jYz[ibrr9m,$|#DU_3ki(,#6!CT^2j*&,#6!CT^2j*&,jYz[ibrr9m,iq(<JF$S6/,G:i:X<AqLs,qh#R8~1)v.,D.R!j]):&%
-Gulf of California,SlOEXfq#|,LXe_{R2k@,Ktd^5Q1j?,Ktd^5Q1j?,SlOEXfq#|,BU*(=#&k=b,Aa(5k`u_H.,CN1N1S@Hy[,"u>bFUX4,^("
-Polynesia,"d5m8%D6,;u",6eYhmwf$x:,5%Xglve#^/,5%Xglve#^/,"d5m8%D6,;u",LXl!1P9Nfp,pj`8ER+@;H,B!be^2p5w-,t!YaMvtxM)
-Melanesia,o9{x<AyA]B,*iI9yt!tE[,)*H8xs9sa@,)*H8xs9sa@,o9{x<AyA]B,HiMLHEOc_m,gZA|73/rf@,I}SX`lcqJ9,fl~nzy1ZAc
-Scandinavia,He!e=h?_2V,|QjQzaB=bl,{miPy~A<!k,{miPy~A<!k,He!e=h?_2V,M(|D;@jB#D,N<Zjd9rV2&,AP>P}@<F6G,"Qqzh;Z,9&o"
-Sea of Galilee,QSq%~rFaP-,g[2mLk*^>K,f01lKj)]XJ,f01lKj)]XJ,QSq%~rFaP-,pi]:s4:9TG,Iktca^NUQ,C8l&[)j7Y),"A`,,|zaW//"
-Sumatra,ck!6;xK$/^,5Wjfxq/5vW,4siewp.4[V,4siewp.4[V,ck!6;xK$/^,D!9j=Ss[H),i2(em&ob8T,r)k(h&xdEF,vHOU`CM:P+
-Sicily,n{{o2K1:dw,)II0bDa)P<,(eHZaC~(l;,(eHZaC~(l;,n{{o2K1:dw,s)}(&(C~qe,wj)M@s{]YR,jov_[O@hK6,bM>er*)`9o
-Mayotte,xqrJ^d[.(O,=23.F{D&oe,<y2-E`C%:d,<y2-E`C%:d,xqrJ^d[.(O,Gp?#Ik&V&F,b/*Gfh]U>A,ru#Hv&<OO[,g67ir]U+=9
-Réunion,vrn%j%6{nu,;3ZmV6f?Z:,:zYlU5e>v/,:zYlU5e>v/,vrn%j%6{nu,IJ6D7S}LvU,nq{:LP(wy=,l$|!y^BHT^,F%kRV:W:T$
-Falkland Islands,p#R$-mG/L,ikhCtY+vE,"h,gB?X*uD","h,gB?X*uD",p#R$-mG/L,f[E%u}3F%e,hME8pvJ-]J,"sgfCxE,%}I",xA+]rlW|<7
-Europe,oV/JG7fwZq,"*_v.+0Rp},",)3u-*ZQo7+,)3u-*ZQo7+,oV/JG7fwZq,Hm4bJ<Y`aA,ofER|_J~:`,Dp?|DrS.=x,dBTCh;2%Xv
-North America,bD?R}i8_[c,4(B@Kbh=D5,3LA?Jag<~4,3LA?Jag<~4,bD?R}i8_[c,wsH3aZT9(O,k.2O4>+A!V,"E^e,*~,>&|",B0j5`h}ycY
-South America,Lol+XIvY21,b0Xr{B7Rbr,awWq`A6Q!q,awWq`A6Q!q,Lol+XIvY21,P4d|2~&E#h,z~`99rF8Y^,%Z}v@QXG-,AUQ5QqT7N~
-Asia,Qlib4)q2Hk,"gXUNd92V,%",ftTMc81UP$,ftTMc81UP$,Qlib4)q2Hk,x;/B{evQ?m,u9:IZ@Uo>l,gJpb~!c0G8,Lg|45@I{1+
-Africa,pwwZu{7f~(,+88}6?g}LF,*E7|5>f|hE,*E7|5>f|hE,pwwZu{7f~(,b~j)uKz$/r,NvOwi0qs57,FyYW/{EEO`,CpZYay1jbg
-Oceania,qFuGdDx^Yv,",*6+Pw9<|;",+N5*Ov8;6:,+N5*Ov8;6:,qFuGdDx^Yv,lz;Aa8Mc)h,xfB@_iTV&b,A2*i`{j|[I,omFN1!]szI
-Antarctica,Cf2@;p<aL,vRsTx1yME,unrS^0xLD,unrS^0xLD,Cf2@;p<aL,M%RATtq>65,h*-O8Wp^BE,]xe(O=bdk,DRY)+ITFX-
-Saint Martin,t2&ri|[Un:,/bn3U@DNZN,.!m2T?CMvM,.!m2T?CMvM,t2&ri|[Un:,o!L7Ln:)+/,cz=5m*@Fez,Q+I:vHQr7%,c7[u_eSWiy
+England,e+/O]%*qfk,7rv=E6qjR%,6=u<D5pin$,p);vRzMs+W,"iR~,tG{Val",C{]JF%%mr*,Jm&ky}FZz?,K`AixN?4fO,M@9EfpNi;z
+Scotland,h~5xz+=ke~,!Le9##zdQ2,9hd8!!ycm1,Ive-9<)?/,dYU=!{y0JI,CzhyKE{%zy,bms0vPoZ2i,yM2(NER.TK,Gpeah<lh@u
+United Kingdom,s9-GL*@AXD,.it+:!Ct{^,-*s*/9Bs5],o6puwHE{j4,o+)poCG*[u,uMj[iKx*FT,OIwD?Vq[H},Ca99PA=59O,"nN,;(#X}Wt"
+Northern Ireland,cPO|Cru8n<,5>=J&k61ZP,4X<I%j50vO,ua?z9KS@^h,rymWNfd[Q[,t2Q}Uw:@3V,b9(smVRG!j,"oTXQ,6j^=,",b4O.fdq=&&
+France,m*#%sE.`.;,(qkm4xu>uO,&<jl3wt=@N,o.l+o.aIv#,PgW-Gd/F7?,qd!suvo&1v,G=a}N]t`St,z&9OM<varw,pk+~~g89%y
+Wales,hNE9}>;Q&-,!<)iK-xJnK,"9V(hJ,wI/J",i+%_VY]7bt,D_u6CIg+wo,zT0L2L~T>H,ry#$]bo`k},plhRl:Tz/O,Ae@YR@cdSW
+Georgia,jN|NAUP*h},$<J<$N>!T1,#VI;#M=9p0,vwLrgavleL,emhqi6m<;X,rNr_y>Sm<E,hE`:7lrR4P,F5Vc$<OC20,h>OmJ~oZ~|
+Germany,"j|z@PMgdx,",$J#C>FS{9J,#f!B=ER`FI,umk_Ql/M`8,K-DUUlt#`y,vt!WOLxZl$,Qhq[TBO5H),HM%kKM-7l.,gM+}.:OZH]
+Greece,n+t>2`:;P/,)r5Ab>w*>M,(=4za=v)XL,F*@Hxe1UYX,dSwjDNnc7[,nG#=Zxp5Qn,yT?~lnZ:gX,O8/WkWCPZP,wH[5PSfX;K
+Greenland,ilGtw#=asM,#X+584z^4c,!t*473y]Ab,oTmq$Cq1H`,fWbYL=>/W&,l]+1ZOhWt<,jI?2qf!yDb,e(k0BGyL4h,Qi.AoC*UvT
+Hungary,mcc&0Kq^xE,(OOn~D2<9_,&kNm}C1;F^,fe<{h`wWIF,"L5j),}Ge5(",u3}~&(A[aZ,w]]>DB_&l`,"z+,{cjN9md",j^H$O[w*tW
+Albania,gz9${p}er*,9#ilIiK|3H,8HhkHhJ{zG,dTNjd[5|Ge,l$1j[S4Z_w,noQ|9=PqcG,PiubQg^Ss5,Hp1dL9r:*P,O:){fAE+[h
+Andorra,dY96`C-f(_,6|ifHvt}oX,56heGus|:W,e?6[KX^Js+,AY#z1NqLE<,A7Cj*hqC7[,I7y6V2sDdB,CY;OB`EDX7,KUSv4_ZftC
+Austria,r>aI-$$|wT,-AM-t5l@8j,",{L,s4k?Ei",CJb&~c&tZv,po@@>#g44W,pbX.~.6OJO,v~cPQn}Wc%,p((H!2~3O7,f`?#zj#)DE
+Azerbaijan,"k9E.p^<u$,",%i)u1<ynlJ,$*(t0;xm-I,"0/,+rSKt6",ru^aT_ML-F,AQZNs:<Ihn,b}AIti8H8S,oW=/gF6ZOL,"x]u},H#?K~"
+Belarus,l$zM~ihPFE,&l#;LbTI*_,%-!:KaSHN^,qTFGENa@Y3,eX=4L.MZ/),D8N9aGT(YL,kOtGr;P3}k,Cx2EH*D>}Z,"B,[GBme-:n"
+Belgium,jTNoKo}Bu+,$]<0/hKu6I,#1;Z.gJtCH,AtMq%)YA4~,j4W[{Wd$i.,gM5c_bst5A,pJE)w+ZJK%,LW*h#/!%&m,rF%zt5M&?-
+Bosnia and Herzegovina,mz[>>AxIr4,(#DAAt9B3u,&HCzzs8Azt,"O0NI(S,j2o",g3SU#SH>>e,Pqi/=VQrpE,?R^lQY*D*,cU)|/vPi6j,z9T_hmmT*f
+Bulgaria,u4^lH.xem5,":dFX,&9|Yv",/$EW+%8{uu,m]_=p1zwik,yLv#s7(0/U,e%6%K/Fo7O,n8DMh4+UMz,M5*2c!ENJ`,v3/LK?TI+
+Croatia,bk2ByZIeU+,4Wb%!S-|^I,"3sa$9R,{2H",uuu#3&G{(R,n`P0w@?q1u,B&Pa`TK.W@,DNb~sC&J5%,ed!}~imM[!,GO8K><b?f2
+Czech Republic,twrhzJ[k:Z,/83T#CDdwp,.E2S!BCc]o,qMOzrk<+(:,fy^;okm_1k,gMpU6QZpk{,if&Ipt4{R!,pV`:gi7=r2,wR=%k%E3:i
+Denmark,kS)hDm%w}R,%[pT(fmpKh,$0oS&elogg,zXq}ul(8_E,EHD^CXLh4!,xT>UY=~g;v,gd(%cHqsMU,d!lJ)zdUTJ,wh@G!lN$Q|
+Estonia,"AES],s:8=","t)iVs4wh,",sMhU>3vg+,i_0H+>}|<.,d55<bwWcif,y29//}tZ9$,paYW617a]n,gGm>+9`k&,w2^A.*A;0^
+Faroe Islands,k[)#L4.[v3,%Dpk:Xu:7t,$~oj/Wt/Ds,"G6=c,ll^]`",Fwsjx3/<>H,LKI5~A(OZ!,qLh1v`1iQr,dG[-P1]Ly-,ca`<lL]SBn
+Finland,k}A9]O:0xw,%K$iEHwT9<,$g#hDGvSF;,jk_(_rr<<!,n{xEq+_:c{,Q`OBBA(IqJ,f6}E@C#_3N,rd_(OgnX-P,lsc1G{vU4.
+Iceland,j7eEZkzsCZ,$gQ)}d#l&p,#(P(|c!kKo,"IJG[L,X;A3",rQ)Q-EabYy,BCT|*-aN8t,x4g!MZegS},trUg0y&dqG,C[bMs5PN|d
+Ireland,s<_WLSB3I/,.yG`:L%W-M,-_F_/K$VQL,"vaSXyU,d,a",oLdeL6a~[X,"l]B_A,?ph!",Gir-4TL#W$,p/C10M3xxF,DVc[0B1#@*
+Italy,cYKvF#ptF7,5|/7*41m*x,46.6)30lNw,L[=I7EcROn,b<&&OM3fYy,p2-()%uZj7,"A,M2k`~Wd[",COfUkybfx],P;wx%Rx}g%
+Latvia,m)WUtJS`H&,"(p`^5C[>,E",&;_]4B@=PD,L&#(>5c7a*,uo7@ZxIP[$,It2!t/-o?>,ld2~^b3]8e,"lQZ,yi}j,|",i3-W.8A8pC
+Liechtenstein,l$2O|9w`F~,&lb=J28>*2,%-a<I17=N1,Q}6:Ng``xM,dmsIj2JJlB,M*;rH]4K.>,B}gk}F/NJD,c7Zh2xn$t_,x^M8w2)s#:
+Lithuania,kZ52zV#[Iv,%}eb#Ok:-;,$7da!Nj/Q:,upq|kJ[Qi$,eYu}=wB+0H,HqC57O<OYN,P<8J|ziSx_,e=OVM]`Q{U,ODx_iYAqK(
+Luxembourg,i2]v|D3@:j,#bE7Jwc/w$,!!D6Ivb.]#,w1FM?@j-tk,u[#kd&*}Yc,wO[~:de]T,GvL1T<pl)T,"byp9L/7/,y",oU<~4jjCyP
+North Macedonia,r5C646H*+*,"-e&fdZ,!rH",",%%ecY+9=G",gPWIY|dqgC,QKm&4[Vr$t,B*Me@Zh_[S,H[sth&^jGj,"HL//^#,,5X",A&@FdL>j&h
+Malta,nIfRn<aY:N,)-R@Z+MRwd,(QQ?Y*LQ]c,hBl;b1akKo,l2LUY9/|t],"f=(W,pEE)M",Qz/GWg%Oi,pfZC2}Oawc,dnY]_1$e<W
+Moldova,5S(f7%O-$,Y[F8gm=t5,X0E7(l<s4,kbJZsU]Tm~,Dh89q.%Zv<,mn{KoGN.?b,st{N3o<qmk,s!x^ui`nhG,u<w5s|M#Ds
+Monaco,m?}%V6s8]*,(BKm_Z41EH,&|Jl^Y30aG,x)ZvHsvNcz,C[hSE1x])},pL;e7uiX=l,"hs,ph6r@5",kYE~9)8V#3,JO{1$2yxOD
+Montenegro,uRo^w#p5Be,:@0F841Y%7,/ZZE730XJ6,nlky<K>nXE,j~OT/nTkAt,D!-|+!*eBX,Gn220)gYMN,p#WecI-Q`c,l*S7j866t<
+Netherlands,"o=,%hU&yX%",*zsmTNnr{D,)`rlSMmq5C,B)M|?v5vl3,eX^dJ|[uA*,F-eGLxAZDt,ImiWQfE/Wg,ca6|9M[|.3,I}xtas*<<=
+Norway,lq`T^ZBF2Y,&2H]FS%ybo,%yG[ER$x!n,DUa%sQ;0;@,t9&OjLNz]p,xaacSwZi[n,A`|*K1}2WV,K0`3{Z#>H&,HX#;I12-Gu
+Poland,f>c7x2E]Q6,8AOg9V);?w,7{Nf8U(:Yv,IkP885[1L6,dn}H9%A|!j,PSEKL{AHnb,wz:QAN8%&+,QYr^22xCo3,O|!r8pZc_@
+Portugal,"q[S4`,F0D=",",D[dH$*T(Q",+~@cG#)SLP,h0~.:5}&Q8,K/#FG8!}DG,Hx}kMe>iu~,elHzZb0RD>,MjYBzKMsYj,c0X`Rdpvdg
+Romania,"jCd]`-=k,:",$&PEH%zdsN,#KODG$yc>M,INr2(vFB[p,zU[B!jrpgl,uv?Z2p<%;s,EEpm1lUrG],iOD+[;vOc1,QO[lJt~Q]N
+Russia,vf)G?[_?Pf,;Rp+B:G.>8,:no*A/F-X7,Q=UkoGw%47,wOOaycR~z&,M%Zo)4Ex%5,fmanrW{ILh,i`?s5yONk<,u3u7Z|VQV`
+San Marino,"j9:K,~DQ2v",$iw/s](Jb;,#*v.r[&I!:,HsOJP(RQoY,HbTQZU8t9?,MY>?+-m40S,drS3F@Hxm;,NIKs(pApAY,t%PfM!!RPu
+Serbia,ui3>b-?a@m,:UcAN%B^C(,/qbzM$A]}&,J#u?@$XnR$,M7m8p!;nP0,KM9;RF<Oa9,vC~!WO}1Yx,"OQK^$9xbg,",A:WhEL~x!A
+Slovakia,qVi;t%/`F|,",_Ux56v>*0",+3Tw45u=NZ,iB7LW}8*Ii,p%wZ4zSjCt,jpd^m*aK7%,Cz:.t]Ga.k,u>]sc0f?(|,d&Z;v4SLqS
+Slovenia,g-]bb&[.E!,9tENN7D&)A,8?DMM6C%Mz,vbEn[U)2cf,o|SPdBlcOk,"hRH,A7qwWn",pQlr/JYlFs,fQMbKoTu%<,H/1j+}vOwc
+Spain,f21=-A~W;~,8bazttLPx2,7!~yssKO^1,n65[nUZiZc,neb-=f&6r^,k[^`V_WQ^I,Q-1OO^)n>C,P+Jx`aqYih,qv@;*gj=VH
+Sweden,sT5=H|@KU|,".]ez,@CD^0",-1dy+?BC2Z,K6g6$oK|jN,pnd}~gw/:?,"AhCfC]V,BF",erbhQg!RK],b.r+%C+uUG,IlH%F{np<[
+Switzerland,lU@C3<C8Wk,&^C&c+&1`%,%2B%b*%04$,O}c<W!@%aZ,bMw[aotLc),JD*D+bih|F,gyBy@/*]JR,KRSC>TBXX(,s=)J}uTu.N
+Turkey,jDA-V?/hVj,$($t_.va_$,#L#s^-u~3#,g[tAvcrR3^,wPY8.I+[Xh,wM29>6E7w2,fn`TSL4H+K,Bo5dwc%z#M,GilXrl.A_%
+Ukraine,h_9=mkZXAH,!GizYd}Q$|,9chyXc|PI{,Ft$h3i.|l.,cJ%(LRs3)q,Lh8)I$R;q>,"w,s~/*1#Rg",C_6GTKD=fH,q*^h!N31k*
+Vatican City,mk1VltJl<],(Wa_Xm.eyV,&s~^Wl-d_U,y8u|!Om27i,MnfK7af3~4,c@Ms0SL)sn,E9ORP)qdh9,msv?k9JTsv,xc^[E/Z[$R
+Armenia,"c(,2{yXI#E",5osbIr{Bk_,"4:raHq`A,^","lo1wB^!`h,",>1ErI|!*U,G4t&;Hch6N,ERCyEa-V]o,s3s^.)4kHT,(;;{-bktU
+Cyprus,kkbYQXw5b;,%WN|?Q8YNO,$sM{>P7XjN,y`v(^%tvG3,w`{+uGys`~,iP!?$Z_Ki5,A1fj8m}V_0,e90l[|lH!I,"FOI,VR<;HS"
+Kazakhstan,ia8as9sCY|,#MhM424v|0,!igL313u6Z,uO%6i;{0PZ,vxq=QA:/`z,p|~)@{)+S*,pwG/f8TA%+,"K[L!R^!9Z,",b2;iz|xg^@
+Egypt,j%*8gN)q>d,$mqhSGpjA6,#.pgRFoi{5,Ddu%%IIGo*,"N(,;S#&N9e",JJzRb!:b#h,LN}*YP~{-L,sM=)Xv_Xa-,uVs:]g8l.&
+Algeria,bd~Ght5tLR,4PL+Tmem:h,3lK*SldlTg,rl:ZBh8sp^,DO-=AqS[Lk,z^#eqWYO-D,hb~_{qK>D=,v&-O]]=OEZ,FBWKraq$]`
+Angola,onMKID2d;D,*Z;/-wb{x^,")v:.,va`^]",cHz7UCnS&i,"L1&JVH|{R,",m.mLjg-{lM,gCZT`M|9xu,sGn#POf<9-,F[Hq;*V/7K
+Benin,"q8fF$4,c6_",",hR*lXs`fX",+)Q)kWr_&W,wAQL>iJ/-],b#r[:tRj+!,Qt7ILf!6y2,"ssdH.@,b*<",Pc50gy=WZl,[&[K^KiK8
+Botswana,upiX0g1quR,:1U{~~aj6h,/xT`}}~iCg,cM;m6U=Dg5,G4K|pWoffU,naB8r`cM^+,H16eX1]VWw,Mmj=@>?Sx{,mSow!CwtLI
+Burkina Faso,n:7&>YT5A=,)wgnAR]Y$Q,(]fmzQ[XIP,FFMu>hPw;u,A|BG)32=10,xMDjNS>?hL,I!PNDUSvR|,q-&Hq~16&{,J.*@Nk4>0*
+Cameroon,j2IQ=f=w3@,$b-?z}zpcT,"#!,>y|yo#S",I_Q-5hX|5;,C18`2)zTm(,DBo3+cT-[:,Nf8Q{=WT+v,e8|;;S>xQ.,B;S:<cu0^C
+Burundi,EWXNc<g5),x`ndOySe9,w4mckxRd8,[#-i4q4Hz,k[{=KKFtb8,v/ymm:8cf7,hEB<R*c15),A+}@K7X|kA,"B7hcD[}|,:"
+Cape Verde,gFOojQO(MH,9*=0VJ=8;|,8N<ZUI<7U{,z7[5xEgcrA,E8sr_C_vb[,vI7@NGK_Rr,b6L`KDbdIg,zumu&z#g.>,n$t4JTV.L[
+São Tomé and Príncipe,gePC:Xt_nW,9Q>&wQ5=Zm,8m=%vP4<vl,Ay%EM@L0b~,x4(t9J8nNQ,"dt/qfm,mMR",jOH{z(39<b,sp;kVFWNG~,"we!,qZc~VX"
+Central African Republic,vNiD6A.v#s,;<U(ftuok.,":VT&estn,-",bsVR4>6gl0,"p~,(pas|?P",I/zO]{Q@(q,hqBB(<N!^q,Bapr]RwJ#?,P.ls/JP5<}
+Chad,?n!)c/h=Q,.ZAGOvTzJ,-vzFkuSyI,QykP%i/vKj,e7w}$Wx7yb,InSmtkntKP,dozwSc3oL_,IuT|OM*Nw~,ljuf!A77m!
+Equatorial Guinea,gYIoR`|AxW,9|-0@>Jt9m,"86,Z?=IsFl",bP:bhgKryC,bK<b=p-Thp,m-W32Cjt+v,xD;}}nO&|5,q>9E7+;4K.,m9{}Vj*h)B
+Kenya,j<egqG@)EL,$yQS2zC9)b,#_PR1yB8Ma,G@(d+tSaA^,G{5yk85S92,u?7-e.O&if,H^_J<Y5+Lq,BP[&G+`3;|,hB_EsBpVEy
+Comoros,t`cagaWApo,/HOMS^`t1*,.dNLR]_sx),m$gS*RQqQ1,w9bE`pR=z#,bu.JnK@qu%,taEpjjAUDi,EjFv^:qmnZ,"k$T,&qpZ_E"
+Ivory Coast,jN^Vc%9OQ5,$<F_O6iH?v,#VE^N5hGYu,O#$FD?t_j),or<mz7dcH6,L!)340&$>j,"CP<0cpy;,I",f($keyMpus,B`1@FnD9*.
+Democratic Republic of the Congo,o3VS!KWb/@,*c_[jD`_vT,)#^@iC_^[S,o#s^(c`}.G,yRZn!>(_#b,IEVE(R=UT_,Q!DmMRZl:C,xLWoq0vCna,Nky*kq6)GC
+Djibouti,iR;U<J:CJJ,#@x^yCwv.~,!Zw]xBvuR},"w[%X~D#R,7",k+4CLKx35g,f;ryKmL?JH,e@]nUPgXPS,i%DV(Dbx=K,dJX+VxBemo
+Guinea-Bissau,i^J8&$(1]|,#F.hn5oUE0,!b-gm4nTaZ,CY~?X/vp+j,q%;R^5+|lP,vg&(+g]]yT,JumHq-w(@9,Neqxx;S4OH,ugyWN%[pXR
+Eritrea,pS>DrFhd%u,+[A(3yT{m:,*0z&2xS`./,Cu].QU#a&l,Q]0R7JuJ6g,G4?YxB/<HP,NgIL<U_<X{,GmH*JA[[k`,w5=:(t5%R6
+Ethiopia,t|h3|;E4g{,/JTcJ*)XSZ,.fSbI)(WoY,hX`.aRn$&{,NSVN;H$s)m,q<##9ET8w4,g_banf#h(Q,s5?gh*QP;:,E[0uav)J05
+Gabon,p.yv>BQ470,+u!7Au?Xgq,*@96zt>W(p,IThTxqnu;|,P*4KZ6]?rf,Nz_#ah$j&d,A4mx0mYQ.6,eCQL}h5w8Y,FGu[yfPiJ7
+The Gambia,f#4-L[mp5*,8kdt::YieH,"7,cs//Xh%G",lW;xJ;HJv/,M}OReg^Eem,IoHWaA78;3,F9=}W4o(m(,i$q|D&dUr3,nh!${YsPie
+Lesotho,oNpApS<AoJ,*<1$1Lyt0~,)V0#0Kxsw},c(A-(Xa1)x,pRN@`OrOhv,t(:iXC>cS>,"l_u,7Sl);4",tZgE~cq(oF,bkjWZ<Vg]U
+Liberia,"nsS59c`VL,",)4[ei`HO:J,(A@dh_GNTI,"hv3J+WS`/,",cIOEmhU5Nt,w~5sD@C~%!,sp#%Uu{jxI,qL:(ZnK[{b,KWY%fKd5dT
+Madagascar,m{noqE29%I,(IZ02xb2m},&eYZ1wa1.|,y;mRF(PX>0,oK)C745Je~,p;&<%/w5b|,O>:Y)[/m@5,mB&*r_Fpq%,w3V@j|Foq~
+Malawi,sSW/?WMy17,.[`vBP;rax,-0_uAO:q9w,"q1DvZ4Qkh,",B5/<2!_D3h,jV+V-M0[9X,J@?!E/?|:y,q4wi1(V&xq,pD{#)wT+1u
+Mali,d-q4J~CNW_,6t2d.]&G`X,5?1c-[%F4W,k{y?<`|#63,"n,VX3H7IE:",J>b>D;vQoW,"bt,AY},y$2",P=:bxc_JC&,f?dUt&>$PS
+Mauritania,"jKO,9y0M;#",$/=sir~FxB,#S<rhq}E^A,ny_8#ZQA/?,"P>,2#H.@>i",AnTl}_8m=/,"G:w,Y[(aW1",tUW+`.SQo9,p02Yuw`G)/
+Mauritius,skOM(?n$GG,.W=;o.Z5+{,-s<:n-Y4O`,svVKQZTWFU,ELkg0G|C?W,kC{ALA>P%a,OB*1GftSKF,AX<o!y5NLm,hj]p(iMKl7
+Morocco,mi+kf0LTW.,(UrWRT:M`L,&qqVQS/L4K,"t,2AZ>_CA/",b[oi-M:re$,Fx4sZh>`:m,q?uiYsL{dZ,p$AAnTq6oJ,qjZDlzf]=l
+Mozambique,vgdj#X?8dB,;SPVkQB1P[,:oOUjPA0l@,"n,~jhT?[]W",qD4Ir3_WvI,AX#-0[v2j?,tRCc37FI3F,o0AQQ^2)G6,b^b:}HG<(/
+Namibia,mkgcU7[bA%,(WSO^0D_$D,&sRN]ZC^IC,]#3u-c%5X,AoE=M5R+:x,dr(`ZC<V%p,b5~CCSrPP.,t>J`KZclA6,p(q*slFP*F
+Niger,jcu!gLw/&r,$O6jSE8(n-,"#k5iRD7&/,",Qw(O&Fnkul,vlABC@3)lD,bND)UmT$s;,L@{q~To$1C,ds<d0w<UR-,j(X|k-_Sv|
+Nigeria,sB7rZQsR<l,.%g3}J4Ky&,-Jf2|I3J_%,Hk9k3U@-DA,lalXr{5>N~,g[l><1FFUo,iT>Kc}4kE=,c1(m|]%(&c,P~zp{JVRjt
+Republic of the Congo,u|I}oElaH),":J-K0xX^,G","/f,JZwW]PF","LG(/,IHQi@",i$+!}pvHZ(,sH*CmlNZ<I,L_#MCSsliG,N-%-M=n!dh,lNTL4T}K1)
+Rwanda,"j)i)pB*HJ,",$pUp1uqA.J,#;To0tpzRI,xwNS`|r~1x,l[H_#9Xj.5,Kx0E[9ibDy,M_^<HEN]5=,n8ieJA{+lP,"OlYF5,:|Q3"
+Senegal,t-0>F]bu>P,/t~A*;NnAf,.?}z):Mm{e,"qJP9,I/X;?",x1I5QDSZdm,P*^/<)(KjW,uoblR~tJv{,F&@Rc;dl]z,y=oLcr9$cQ
+Seychelles,hrI_uiW>E],!3-G6b`-)V,"9z,F5a_,MU","H38F4o,>An",p]3f+<QuK[,o-iAF(Oe;d,A#PXVu3{OG,Q+z>Go{V83,L3Z}n~/Szn
+Sierra Leone,uc61ToT%gt,:Ofa]h]6S/,/ke~[g[5o.,xc)G{&Ta22,"z,yR__YX6x",oBc!CE4|t8,"J/Z,LIAPP>",J[n$C~*-<~,t&Ov:{KJHy
+South Africa,"e.t$Vi5,>f",7u5l_be$A8,6@4k^ad#{7,DS~l]pq.y<,"i3+,TcHF,N",BA4?dToa9],"pcq,]2w8O[",.9`Zb?|4],eqi30~lJCU
+Sudan,k/u1:B%DJH,%v6awumw.|,$[5~vtlvR{,uNyx=*R.$~,G$NEO(W.(v,tcsX~cQjI2,CAUBpe+}Rh,"sFwd3<b,Q*",yJ+?5Bb~=:
+Eswatini,e5P*D#I{m{,7e>q(4-?YZ,"6%=p&3,>uY",E2g&j~V_+i,ml7O4E=o<>,Qe#D4C[<+m,pMLZoOPY5w,j!9GChs@cQ,p;W>c.=a5.
+Tanzania,p:SPZ:e/*[,+w[>})Q(qU,*]@=|(P&<T,umTKoLZSfc,dryK>>pO;},C]<t^C)#CC,K9nrzyH&<X,B{FDr5`ABh,Op1]SnugtV
+Togo,"t+v9b--,qs",/r7iN%t$2.,.=6hM$s#y-,hZ-27c=iA5,"s^sd#Qsi,{",O1bKEd;`i],mBU4P!~(nj,cXB4#4>X;-,z8UXM/Z23%
+Tunisia,fV`&p81%d(,8_Hn11a6PF,73Gm00~5lE,H(5ar5kY/Y,h<BBS_PmX6,Fx%kVt2%kj,JqECz@.%4i,b&EqNhY[/p,N&=0FE?0K3
+Uganda,"gsS{jR,]|Q",94[IVKs;Jg,8A@HUJr:ff,"oi2j6zc,T]",p-Q-4>W#GK,v8pkKiW5;U,QU|9z>>-i<,G;pW`r5kYU,DnUNQy>V@c
+Sahrawi Arab Democratic Republic,cAlyc~G.y%,5$X!O]+&!D,4IW9N[*%GC,bDx}p^DSVL,kQssZ~b%|u,MfwiBI+|=9,dQpb|V+vI#,QcXm!E@Yw1,p){pPjR5:$
+Zambia,"fxAN),FAc$",89$<p$*tOC,7F#;o#)skB,hN=Lly0+D{,vwR_K?gn6&,zWj%QH!y<q,"Et,iKxkLUP",Ef]sAhH-1=,QyZ%*OdzFY
+Zimbabwe,r<N4LAAnnB,-y<d:t$gZ[,",_;c/s#fv@",w#;7*w+/l+,yV;KtlAuQ?,E]~7Dc-XV@,e5i.x%JIir,E;nd7c[w(:,Q5Si^%B~:x
+Canary Islands,e?Xq9gy=@[,"7B{2i~!,CU",6|`1h}9+}T,wt?Q|)Y7F1,J$+%7z?.y*,iV*VDI/knn,I6q=nh1_(R,d.;lCBC_WK,F+l?rc6nr?
+Afghanistan,"m5j,b/y<EE",(eVsN(!+)_,&%UrM&9*M^,i_cTqW/(1E,m=n=4WFqE3,K+Rf&9RCYP,L++V2zV3fB,Kg*_Uu;=~F,ubj(k(`p0:
+Bahrain,stRa/S(0$F,.5@MvLoTl`,-B?LuKnS-_,q@wPIm/;#),fFI@z-#q(E,wC(@I#Qj=_,w<=bLWa9^e,D/^OcViV>B,KHEo&Oa7_F
+Bangladesh,l+>Ki!j#v+,&rA/U3V47I,%=z.T2U3DH,DN*^.Q~HcI,fLs!R5^k7e,C%r3!}*o9-,gWiiNVbwTm,dm/G5**HY~,sj6y@z=dRP
+Bhutan,kQ:NIhJy~E,%?w<-a.rL_,"$Yv;,~-qh^",x2E6#%E!/p,I%N^RyEm:/,d}n!kX+/ph,KR0|YigF}Y,j/kD7I4;Hg,"vl*,GQz^vQ"
+Brunei,sY>@9w~i^p,.|ACipLbF+,-6zBhoKab*,r{g3sXk]Cm,ILj+.~~7_X,iR6^@_]dvR,N>!/r-|iKh,E/MT}kv2tI,H_pUK6Xu]`
+China,mJH4kwPF.-,"(.,dWp>yuK",&R+cVo=x@J,Jcx)35]`H],ci5EzZT?lp,Did1{bE2yj,LBA=S$7TwR,q37^cz*P9W,8CAB|Q`3c
+Cambodia,bW)ch:vs1P,4`pOT)7laf,34oNS(6k9e,bp+p&^O&Nz,tt:.S?c/]j,k5Zby(Llz+,vAR>ZSEGi/,ioJ7(frmya,"hWSXAL,1[1"
+Indonesia,sx|l+io`B@,.9JXrb0>%T,-FIWqaZ=JS,HPt<x)x%Jh,L&YSIviD+L,z.;^Kjw?w-,i>!/t@^}^?,d8zQ]l>xmo,p?*+RZ<OgX
+India,q2#Yv[O0:|,",bk|7:=Tw0",+!j{6/<S]Z,p`7>hfkNfW,Kx5=:O[u*^,uq)KM}CVsF,oQe#*&QQB,eswlz&5_-],tJ&;D}C]UV
+Hong Kong,lpbD0St&OU,&1N(~L57=k,%xM&}K46Wj,C^p96b?pgu,f[U(U6e5OW,l_bSqy)=W%,e[XV}qzx6q,L&Wh0Oh!9*,cBQpjb$FFF
+Iran,mbz=7n[0v9,(N#zggDT7z,&j!yffCSDy,g^hxtS_)Ja,"I[^T<Hq,U}",P{?pBbVc*#,"qn,8N+7Z^{",M75UjrE!_q,GV|.:pW~=#
+Israel,ijP>aJBT!9,#V>AMC%Mjz,!r=zLB$L+y,N@X:<s:Osr,dV#R#|}uZH,Hb~5J(.Fg~,cdC>T>VY4t,vNlrE-EWLf,LH]h^.GA_i
+Iraq,jI9P-f6r3M,$-i>t}fkcc,#Qh=s|ej#b,Kc0|/i[KY@,"B,]AC/PAz1",DE`CrM74%0,"F,ZHHr/u@K",c(O@!xlX|c,z}n.If4:?)
+South Korea,h?a*UKfT_M,!BMq^DRMGc,9|Lp]CQLcb,m`:zwx?UCO,BqW}>:ZSdW,Hfw[5^1FXT,in7S|U&pW],rIn3klxCO3,uU![?ri)d_
+North Korea,r6BV%|..*5,-f%_m@u&qv,",&$^l?t%<u",kfOOt3pPdZ,J4zOBxF6Lw,Cob1W^QJ3F,dm&o}^E:Y%,hs$=I;b%H{,Qmb.+7huoY
+Jordan,i)]+09JUR&,#pEr~2.N@E,!;Dq}1-MZD,G]3ZD2G$ww,oM$V=]IFjW,tOc]hT~n}*,g?oII<6[ZM,rBXL[4*?g5,c#-~c^hZ8~
+Japan,l}[BG9.nQS,&KD%+2ug?i,%gC$*1tfYh,rHNPZJUEFp,bw=b(wfRVC,Gg8=;ywiMF,nDcU{JcnF/,m$4os@Y#(Y,if5[hu6l7g
+Lebanon,mtd;>7T|g>,(5PxA0]@SR,&BOwzZ[?oQ,"f;],oZor+L",ya?+!BD<rP,bhv8b|]kY9,eTUA#N*+_%,l::->dQxMA,eDx9dZ&k(k
+Laos,iW>m(L/~c=,#`AYoEv]OQ,!4zXnDu[kP,CW+/?p:?BO,jKTnJ!T6lc,juCeYT&eX9,uB1!(|)h6G,l57t^$S&*u,c=F0q+d|m#
+Kyrgyzstan,pkj3RPBUrF,+WVc@I%N3`,*sUb?H$Mz_,FHqW?gqMKx,Cw^_3<[mGM,bTd6E)qj]$,oM2[$i]Jg{,Oy&*?<z%kE,o%$r]1QH{t
+Kuwait,euW0jm=wfR,76`~VfzpRh,6C_}Ueyong,HQ$_4*oGf3,H9A(m7f1)9,Pmp+_CoZ`T,CeFx+%T#{9,g:S=I8r:O>,F5Fbm]10e3
+Myanmar,l*j*EE:!Y?,&qVq)xw3|S,%<Up(wv26R,"pcYb[d%n,O",n%Pw}}<GAT,dET^[R~4O3,y-F:kD#HUc,s$RMwIQGZb,EKcj[W^+w]
+Mongolia,d3c`&/1Y^D,6cOHn(aRF^,5#NGm&~Qb],g8.ti_%`5,Rb7MD6j!0|,wOmUda6!>t,"w`Lo,-amU6",Q+8JVQabLR,y!.rR1N]Q%
+Maldives,hXNTVF<:SH,!{<]_yy)[|,95;[^xx(0{,hE&?:>xB0v,fxvMT{|_3M,y*>>K_Rv{P,"pR,WF6cJZz","QL%7i$x/c,",FO/D@z0E%#
+Malaysia,"mk20`,N=`=","(Wb~H$<,HQ",&sa}G#;+dP,MV[vr/8+{>,Re+G*@uJCl,Byv;->|tVn,Fvsev/q[3n,Evr|0ju(D2,g^MDw[q&`K
+Oman,eALZe^HCHq,"7$:}Q<,v,,",6I/|P;+uP+,HrZ~>9NjBH,vy^=B$6h^Y,MQbYhy*8W1,OGgJtMdwEP,F@t-f&]i?`,D^z&W{[{ng
+Nepal,l3Ly8PBxt(,&c:!hI%q5F,%#/9gH$pBE,A_Vjy~^@?},m<$SD/W~so,j^9KkW@1V^,FeM1Z:8]S-,rqH=>+|p}D,n$0d;K4M?l
+Palestine,g<[f89~U)A,9yDRh2LNp@,8_CQg1KM;?,DDzO/+_}ww,Q7W^uZrI_<,HxK!=[v%7I,H4;V}Gjc$p,E-hC9K}m$~,eRztGZ?5gt
+Pakistan,iIS#Nw]tr],#-[k<pEm3V,!Q@j;oDlzU,x7GO_2-WY$,l.HYqQ_/Rf,j}.YHgP+1),hL96AeDkLm,epu:F7KRn!,"mmXmH,@{!K"
+Qatar,"m{oM,jr>C#",(I0;sc3-&B,"&eZ:rb2,KA",i3#3D+l`w$,zJ%%Hz#s9&,h~hx$TrJ9L,d;7/rK:;@r,N<D}v:QnwJ,rVhH@X0hOr
+Saudi Arabia,ln^3p)j3b.,&ZFc19VWNL,%vEb08UVjK,f0b;Rq1k!_,MWm=94b?vO,N/[L&}q{Ro,wt1^C^RyMj,jmR])+zhJo,dYQH;whZ9c
+Singapore,cL?8!xP#Wj,5:Bhjq>4`$,4TAgip=34#,twkWz3eS+-,m>7j+&89xI,s|EEBYpJ*s,K{N|AkKxc*,"qS%*AW?D,f",ya#p*nPn}U
+Syria,e=.VHQ9E+M,"7zu_,Jixrc",6`t^+Ihw=b,j8XG#DTPjL,Ng%@)K)[c{,cm97y|}K9@,H)jJ?RQ{`4,QPl3$nhmkb,i?;Nx?in:X
+Taiwan,m[96fa+HDS,(DifR^rA(i,&~heQ]qzLh,AmEQ/?7Q#x,dctSh&<iaU,"uwH,{ZS,Hs",|a&v3R&*G,zE7(j<-d3N,hqHjJQR@ve
+Sri Lanka,g9v~y/;=z(,"9i7L!(x,#F",8*6K9&w+HE,Iq@M;2CIzf,iYAK36Cua{,t/Q9G`l<(*,p*/Yx`XElV,p?N:RJ`9Qb,caoMw/l6Qq
+Tajikistan,g~%pF`(x{u,9Lm1*>oqI:,8hl0)=npe/,uhYJm4N/!$,PQ6$bI??y6,"v0.(wt0=5,",yJuwsoHp0*,m@%Rs{o2LO,qvU`=w(275
+Thailand,"hE5j*e,Q?[",!)eVq|sJBU,9MdUp{rI|T,oCa[}6b]{J,Bq5H0+i]XW,lJGFm$U&>?,r[B4}qKEKl,O|]ivh~%v{,oVtF.y]H)M
+East Timor,fRSM{K+;[w,8@[;IDr*D<,7Z@:HCq)~;,ymuYBM5)ux,z7wQ8s_Si[,uWjhG1h]m,de.tDgRhFi,bq]dHo&Tn~,x2Ho#9JF2&
+United Arab Emirates,o~}KVA:VbI,*LK/_twON},)hJ.^svNj|,u9/j`LQwrv,qqJpIWfqFB,BAz%}9{UE,"AFNn,$>?6v","J)9J,MA_jm",njbrSU^agd
+Turkmenistan,u-`cspdp)D,:tHO4iPip^,/?GN3hOh;],"B|v&Z,u=T",Ce096-Qwie,hM~h4Ec9ZW,QF&bT0`se),Iva{=NlZof,uRPZ]lF~NL
+Yemen,"e42BpV,P}C",7db%1OsIK],6$a$0NrHg[,bTrCSD^W4m,D+L%7xa1|K,"x(aw,hH&Y[",w_RRz<D>=p,MXc[U*Dc|y,o@l9/@&CEQ
+Vietnam,pD<Pd$Ag@J,+(y>P5$~C~,*Lx=O4#}}},xQK`2V6wDX,Dn/EH3[r{9,zybU=+SV=e,rE0yeh1k~6,xCFE#ual.E,I4?0i2<YxI
+Uzbekistan,mbGXc0y3Pe,(N+{OT!W>7,&j*`NS9VX6,r7L@;3f5Y^,g?)zvSS|6#,jD9{n{|+PU,ndb6k{nIX-,O.[B3&pjNc,JA;WxR7VVZ
+Fiji,gB|K:+r?1V,9%J/w#3.al,8JI.v!2-9k,"vy}j#{dVU,",mh=!E~}0-Q,s|eW&jr[=w,gVIrkH[g_z,w_*e?Ms1]_,ncoVNK:5c/
+Papua New Guinea,lhWI;$JC9(,&T`-x5.viF,"%p_,w4-u*E",M4#3n[]D/T,BGwA6-2[o8,CQy8.z2s`v,tLN$~<D&LN,kQ8x(01<},B*Q><ygyqQ
+Australia,k0{O[6l]bH,%~I=DZX;N|,$8H<CYW:j{,p(t;=_z4`=,xL^i{$Dd?},"LYe,4PfG4a",M$Ym*hq(lZ,Owoj&4yEcQ,Pc}I71FH$K
+Solomon Islands,"r>g<|,FWi%",-ASyJ$*PUD,",{RxI#)OqC",Gh36nI3h)B,O86#Kfnj]4,Rh_*(xz;/],iqg6(sCS87,A7d`$VleNv,Ko1^yAR.yn
+Argentina,n&>e`2FO/S,)nAQHV*Hvi,(/zPGU)G[h,A%emXRt~a],svzWf$x!8;,jDvPRSN7UT,E_Y_gka<wh,sUW(K@)rpu,l{J_M.Vp>X
+Bolivia,khB~(m^@Z5,%T%LofF/}v,$p$KneE.7u,s9?zpnq?/g,"M,j]%f~qLY",hnq?l@KUUT,xBZF?3m:=u,K1#2~5/6~Z,LCs2:t<[-X
+Brazil,spKoFRM4if,.1/0*K;XU8,-x.Z)J:Wq7,Osy[q7a%UV,QyNb5MKVnQ,sLc+1O/t|!,yR{s}{|vzP,L#b;#eu1UR,c@58oWbN3U
+Chile,q8][)Ri}=q,",hEDpKU[z,",+)DCoJT@`+,iyxxWaZ8Wb,hqnhi=ysa:,m|F4][J.!m,bD5Cj?{})5,BHe5zlq%zC,N@bHVDe+Kb
+Colombia,hoHandbYAy,"!0,MZ{NR$>",9w+LY`MQI=,fRSFWQK>W(,B4sHDjU:Pl,L>tNacmJP#,cD]Q9Pd0ZO,Ca[)+1M+q?,heo$u3%xYs
+Ecuador,lmRujD!(A7,&Y@6Vwj8$x,%u?5Uvi7Iw,"lcC48!,,{,",GDX20ZK?Xx,wX.mVG|9{n,F289Jx}!aE,CTD4|lJ}]5,Q8=#jf;Izu
+Guyana,q:XyGf#>Wg,",w{!+}k-`9","+]`9*|j,48",ja9thWdG~?,"do3`,9Ol!H",c#$?0jnW0K,J(!?!{vv{7,"oA1,v5>^){",O>(c0%czoO
+Paraguay,s#:aIK$9^x,.kwM-Dl2F=,"-,vL,Ck1b<",Cdm[YJ2i`t,Gs*[8}bP33,g-3%G(QyEf,Ci{2x]j^h=,A$m)oTJ1BW,m%N$gpC+n]
+Peru,jBd@A?>g|},$%PC$.A~J1,#JOB#-z}f0,BxD0*Nx8HN,cnUAu<NuSS,za4sz~iaR*,I`2u4=)$rI,jxR[;SimkU,rJG$qf|FO4
+Suriname,koI(}OyJ:@,%0-oKH!CwT,"$w,nJG9B]S",mK?UY]$UVp,"zH)c,C{V#j",A}fIE>Pq[I,n+6|^+yndU,lR`ZpmCTOP,DOTLV^*F{H
+Uruguay,e?gIaPc$Ox,7BS-MIO5==,"6|R,LHN4W<",e-#MW&-!m7,yC]*G[N>gv,FqClN*Uskm,A^v{U|AR{a,p/fH$J091^,fk0sh|Ih~P
+Venezuela,o#&RMA_REo,*kn@;tGK)*,"),m?:sFJM)",O_HGdfn7R7,u!WO.fcw8<,vqczM!*!WR,p7}c5wf.O#,OwHb{Mz|$h,"w7J5,@!ZO`"
+Cook Islands,s4E?ZF[E<>,.d)B}yDxyR,-$(A|xCw_Q,rnHajUXn]|,b|Gr(/*-kx,dL;ASbD>B},!lbQb6Q:w,h<Q}<=6jye,Q@3rl@WPXz
+Federated States of Micronesia,k1]FH+s8j@,"%aE*,#41VT",$9D)+!30rS,ns:xfr`B.`,k4o56u=}jw,B>y*UU741f,"jH,I*;o6vh",r@_hV$i3&g,A`?%3b$nUX
+Guam,dWA49p}F{k,6`$diiKyI%,54#chhJxe$,JXC>bWd>&Z,sk!p1OhX-1,b<l<9Sv>;o,G2WhVSEk&4,vRx60WZhA6,O%#xYWz^#M
+Vanuatu,K*b}<I3(~,Dq41y-co],"C<30_,bn[",BNN4wvUA&P,ipKjLUOh4Q,MfdunrN!.(,y&XDZ^<U3_,Q_m!=Xe)uk,fwm<gn03ey
+Canada,e?h=Xhs+K&,7BTz{a4#/E,6|Sy`~3!SD,sOd2&00m?K,P}MIWKA{Xz,C@Qb!4TM+Y,dMQkP!;0c=,vp8J2mcIv`,HzN{~)3NGK
+United States of America,b@M[XTc?}5,4C;D{MO.Kv,3}:C`LN-gu,q382+6kQ}},"k,Tmj~Pw.i",hV^z0k.t6x,"L?:>A,WJLB",K[7:%jDicU,OzZ|9/zKGy
+Mexico,sxOMs+bE8@,.9=;4#NxhT,-F<:3!Mw)S,"sgq|,rEUT>",cep8BP*Eja,vFrU{gPXOA,nNI(>d`5|I,qj/S4:J~Wh,J+O2qUIUz|
+Puerto Rico,t3aZXtpNyi,/cM}{m1G!#,.#L|`l0FG!,Mmy:MH3p-5,"C00t,nt-~8",^@~8x/eFp,Pkxoj6=pZF,c+d=6X;DR:,"OX,mUDIStL"
+Cuba,rPekx@n9:L,->QW9/Z2wb,",XPV8.Y1]a",bb1Lx^zyVu,ueNqs:h=(z,K4#|XaqO:g,rz5xk#1<PP,xm[hZ@]0D2,"kjo~PAZ.,y"
+Dominican Republic,lAxH.CfJB@,"&$9,uvRC%T",%I8+tuQBJS,mSo]}$<EpU,DNXY<9~9OH,"stl,m~cAO&",xxk(Bq-Z`<,cl`b5<!_&X,r#k4%<ieJ;
+Haiti,hZ/V/D&rO`,!}v_vwnk=Y,97u^uvmjWX,OXH#q-u9XF,l!=SCi?>l?,"j1e,tg|Z&b",ewx9/IV5o%,z@fLLI>[@B,k^PtQpRdLQ
+Jamaica,h&`>n98~V1,!nHAZ2h]_r,9/GzY1g[3q,P[t`X50n$K,G5wA};7d`m,qjIBt_WC^1,xddNP~dyT_,Ob.MR2u/-&,i7sQICmsKP
+Trinidad and Tobago,t50y/[AEhF,/e~!v:$xT`,.%}9u/#wp_,CaSU3w{HJO,la.c2n+A7e,FQm}Y9aG^*,zRmOT{Xeqm,oO/>jPN^a5,I=mZ*3?!_l
+Bermuda,gBCR?!O*;E,9%&@B3=!x_,8J%?A2<9^^,b(JUWzefV^,sZ</&q1)tK,h:@GWL?4y1,H+Rb-3u-sn,JM7]2EJ[qX,wY{he1D;Tc
+Guadeloupe,tTnCoO/*tk,/]Z&0Hv!5%,.1Y%ZGu9B$,":?*,_d`iM",d.lZ`^MKjl,KI?g-vLTJ8,LE9jC#sSOE,jpDvwSb-OL,Qg3C+rbaa*
+The Bahamas,W5?6yQZD2,PeSw!?}(V,O%RvG>|&U,N$AR]vQR?L,u#*HO9?|?],"d`,;^d_nt5",N}PXRbob?8,J%7U=$j(Cr,Bp:8AxZIJ*
+Barbados,e{e8vi@^PY,7IQh7bC<>o,6ePg6aB;Xn,jFv`AX2j9Z,c^iV73&0V(,b:(mUH@(`.,il|4oTIh7t,q;6Wv3u)tx,O8La>q*+=D
+Belize,tcneuK7v%`,/OZQ6DgomY,.kYP5Cfn.X,w{[+/hi?P7,gBJKTCx_/6,c0H>DK:hY.,J2r:;Tb}bM,"D@,Q^H)}Ln",d&bsqV:N$w
+Costa Rica,uH*Q(mcRt5,":,q?ofOK5v",/Pp>neNJBu,C}D/)CbE1E,w0Je-<6ym_,"CPWU&xD,31",iT]9Jy+|:B,ebcMj4pw`P,ELV(4@XqZt
+El Salvador,k$1_yaF?9#,%laG!^*.iB,$-~F9])-*A,r]by!Z{bH3,o[GR>HoXjp,Aq@4iLUo[t,ns9RF=A{<?,lWXANkm_ks,gM!|AcSE~W
+Guatemala,dUZ^=SE5BG,6^}FzL)Y%{,52|EyK(XJ`,5H}uoT?x9,NGD}XK^mX},u2@(1}y4a{,oQW|#KNZR!,f.SoIgVf$q,^(x:orV#n
+Honduras,t_h*fbN#:(,/GTqR_<4wF,.cSpQ^;3]E,d_{5}`KOeV,y[:PO%mkg(,u2YZ8>C2[I,QUEZaS<.i&,sHKG^]G1Hi,Leo~hD<WPr
+Nicaragua,q=w[<m2Bk&,",z8DyfbuWE",+`7CxeatsD,b=!Fr*y_C!,z?M@Me}UrK,B1cUA{Hro^,NgMbQSn4l{,xPbky$#R*1,"iKL]@oe;,B"
+Panama,vpOTK6tMr@,;1=]/Z5F3T,:x<[.Y4EzS,P[nc3.TLD`,y8o-zQb(8j,b~C@$BV@fk,v5e#_P()cc,gw%[JT~eOZ,QIn7X6P~>i
+Antigua and Barbuda,m2F|cUkKhv,(b*JONWDT;,&!)INMVCp:,G~@ufSz/a;,B{LJC|+^D.,ddf7bzEG~m,J2R`q[Z2!i,o@zxjV_qcp,qvhov1fh!t
+Dominica,k}4/oj#$~s,%Kdv0ck5L.,$gcuZbj4h-,J32gf}o<MD,efA[V?^$DO,"P,t][$~Axv",DMfp:u>1/~,K~OD+`QJa(,P?8;T>jkXg
+Saint Vincent and the Grenadines,va/ky=f5pK,";MvW!,RY1a",:iuV9+QXx~,dnCkHdCc(#,CTw3Yd}Sx4,xN@x`d<BS1,E{q^42h($(,nm*l%S8r+{,fGB0mK7OmU
+Somalia,"c,5(mUGzYT",5seoYN+s|j,4>dnXM*r6i,M$iq^Ddz$z,G#LLy[.iS2,j.J_!d]H{c,N&H{fk[c3L,o^IIsTJR4[,b.K2|uT9#&
+Zanzibar,gp[h@]y13l,91DTC;!Uc&,8xCSB:9T#%,"cH+7jy4I,m",Cko(o5/eN6,nLS!c^B.u5,yTwB:d{m;m,uc9G:E._YR,o6Q=4QRc:P
+Ghana,gx:;za!?C9,99wx#^j.&z,8Fvw!]i-Ky,uQ-6g&t&/t,K>Dfm{ad5K,uJWy?`0JRW,j[3-~lc=uu,/zj4yGq-~,O6XK(yEdjN
+Guinea,r]*Ioa%$bK,-Eq-0^m5Na,",ap,Z]l4j~",ltf#^eLgH=,t@-V_iMKbK,I[3;:2u9!5,"E+q[fM~I%,",zlk#[1bx]e,Q!&RwY_+~G
+New Zealand,)Y}Qy.3GK,9|1g!uc+D,860fGtb*C,cYWtxb5I.n,G8%+Eg:Na<,Qt?NY}jsN;,Fa.~5.=<;F,tBCiVBcuG_,HU{V)h>->1
+French Polynesia,lH^2D]w;[H,"&,Fb(;8*D|",%PEa&:7)~{,s&%k)X]^%+,qpx1j<_-l5,m~5*]PDD9k,qjeAhS!PI:,lI<3M8p[+),|:r0wYpo+
+Philippines,qx%>fB$d+$,",9mARul{rC",+FlzQtk`=B,b-3J|=Nm69,z|A6R3H)3B,vlkjlV^U~T,m6|Qi!lWAQ,n58X<QI]0p,"M<c,]nB<a~"
+Kosovo,libliptkB4,&UNXUi5d%u,%qMWTh4cJt,G;f97RI^i|,"J,3]AhU%0c",bwsw8$TgX1,lq[V&Ro6p!,"rs3Uv}D,)h",N={U.qMDd5
+Libya,jrM28*HbyG,"$3;bh!,_!{",#z:ag9+^G`,Lng7&qhm~G,"jWy+dd+,ta",d[tm>aNv-o,uCA#@hm#=u,jcwmr?mk}z,OgRSGzP9iU
+Palau,r?E$4f-d0/,-B)ld}t{~M,",|(kc|s`8L",L~g[-Y5a.V,c}m%T+N!Gz,fPO>]fFure,u~Z*V|m1JC,Abp+=0%|oz,gux9;qM)nK
+Saint Lucia,leh^fmrt*#,&QTFRf3mqB,%mSEQe2l<A,uEmYu^%Cdm,xzc~#RzbI@,oBs%LSd4B;,Aovq2LfJ3x,B2:MgtMw1@,hq?[{n24G;
+Bali,O~pXkAbd3,HL+nW$NPW,Gh*ms#MOV,dW]ePHn0<E,FCE{oF+@St,IxLAH)+-_V,J?N4X)hLQ4,llB|P7o^Tq,u._5@pRbGb
+Grenada,f*LO~>!0PN,8q:=L-jT>d,"7</<K,iSXc",xj/*Nw.FyN,I{.D^{85=#,"l[/(,BJdiJ",t2BlE6w@U0,K7t:ah)Nlf,t1sE<.qtO/
+British Virgin Islands,q[}7hk(+=e,",DKgTdo#z7",+~JfScn!`6,I5l?zw=g2W,uu)_`Q0++C,k`{m~8Eb`.,mmn-72S%.C,"n1HR1,WDIm",t|}7%V0{4w
+Turks and Caicos Islands,q7do-wLx%E,",gP0tp:qm_",+(OZso/p.^,HF8bKY!Wia,"c$J,,={OZd",GJT]wWpqv6,iBkK=.H[[*,cx%FD8~SUL,v?vAk$tZAa
+Cayman Islands,vwc3}.=Z#&,;8OcK&zSkE,":ENbJ%yR,D",PcUr6zy#ql,qhlz<GNM_8,"OL?i,z)TP#",yD<PlLql`:,M=3y(}U;7v,"l,[F>UJ/PN"
+Anguilla,e<X;[vACXC,7y{xDo$v{],6_`wCn#u5[,uTx.c_gB-g,emq?3*tP9W,rsxD)TXKC#,i4D*V-sHYX,rMX~]}XH:Z,zz4Ej5gtx6
+Azores,"j=L,YBvsBk",$z:s|u7l%%,#`/r{t6kJ$,M=(.zK+i8],f2L&U-(v+/,tKD)*8S3TN,NLQ8Se/(B%,tTWNp2kfJh,BJvzz<mQn/
+Curaçao,oa87&PB&Bm,*MhgnI%7%(,)igfmH$6J&,"w?},I|jwcN",Gc>|URJcg|,y9[[$e%qC`,dl?k9`s(|K,bPqp-AGH3Y,GH~LmtD8o#
+French Guiana,b^Try&me1A,4F]3!7Y|a@,3b[296X{9?,wU6oi[(~g5,"Dd.ED,HOi&",t6K(T;};3},zR_=AM#e1.,iEf6;Pr<M!,N@2CXFim}.
+Gibraltar,o``:?0>/yz,*HHwBTA(!?,)dGvASz&G>,rJf@3vMORX,J3)Ty17a?Q,"sg,bj=%n1w","M~5K,Lq-LX",AfMgn:9E6@,jZpi[+b>`2
+Guernsey,pz(G*<F93/,+#o+q+*2cM,*Hn*p*)1#L,t)7YT?VSxY,xWD+oGZ~vY,onvgK4ynAq,sKVdix$DBJ,y;=#m2VTao,LvKjC9)Jop
+Isle of Man,cV4idO^r8W,5_dUPHFkhm,43cTOGEj)l,m*zfj4hJj+,G+c6-zDX5@,r]11B;H~[z,emf@Kw7U_W,LB())=5`]S,f&H7U0-[5}
+Jersey,m*PYE=#wr^,"(q>|),kp3W",&<={(+jozV,z#:5{OdBN],g;I=8p!(]b,"CO+b,zPO_I",j{s4{ed!RV,J0UNSJ4UR.,MD>R`2$IfI
+Kiribati,sXzvT.g31p,.{#7]&SWa+,-5!6[%RV9*,`ePFuGBDX,b_#ie@t!%Q,NwEo@VHs_d,q|wSo|9[WL,Nvp;D=X.u{,kA<Bx%0-hP
+Macau,mq)8`hi{hb,(2phHaU?T4,&yogG~T>p3,co2;shq(5S,AGUPi8s%aF,vwc}tXrF=w,o.R(%XRfF<,"p{:,t++CFI",kp&`?`CDeL
+Madeira,h}lnSN_f$_,!KXZ[GG}lX,9gWY@FF|-W,z>%tQDyw7D,CwGQYVm2&`,"H,;72`%LJX",J4U9*&@eJO,CpG.*qzHU5,yp(op%kwx]
+Marshall Islands,"eT<gzg?q,r",7]yS#~Bjs-,"61xR!}Ai>,",yc9tc)O|D),"Hh[ZfFwkH,",hO~G0Ujd_$,x$e/?}ioiX,"fO#rmj#,Uh",gum46?fIJ@
+Nauru,vE[T$`n9T),;)D]l>Z2]G,:MC[k=Y11F,CmEf8|#B?{,PFcyiTRKq=,D|=[nt0eT&,"O,{dn7CExu",r=<RFKhs~w,nB97`B-u)
+New Caledonia,tj&bK}%P!F,/VnN/[mIj`,.rmM.@lH+_,QG_m`Y6OnU,Ql.8m|u}H!,vLL9vrH]jE,vqizD*x9.v,bit-NvK^B3,O-wR/1*Y6i
+Niue,kX]hN=_.c-,"%{ET<,G&OK",$5DS;+F%kJ,H~PFXc^2.|,"k}E2,sF7^}",G5M^3c_/X|,AE%P6;/:4z,"I>,%[aL/r)",M1DF:M)y_T
+Northern Cyprus,"r/B|ra%L,.",-v%J3^mEsL,",[$I2]lD>K","CuDj}XI),:",FGrbm!9:Cd,bbW|f)4_>u,i;wkVQEC8~,"q,5sUDZJ@|",H!Ms:!^6Ka
+Saint Kitts and Nevis,b[(2`4t&?J,4DobHX57B~,3~naGW46|},"j]:U,18j(c",FMj}H;knqq,QP7}%SW/px,w^9U1RGI}b,"fN1A,qu<xJ",P$;>yK&Bb#
+Samoa,qvITjNxkLN,",7-]VG9d:d","+D,[UF8cTc",c+Zk;oa>e/,d9@W=6sKJ-,h70gtJ%&xI,Nq3Z?3&|oE,A16VT}*wpu,"NJhO,P|nW`"
+Somaliland,jX=#G8wu#(,${zk+18nkF,"#5yj*07m,E",dy>%OTh=dS,F)s+:]$(EA,sOvum<h.&0,Dy8wkcY4!S,Ip12e4sGC?,ki}T;HSiij
+South Sudan,l&#7I)Ah/E,&nkg-9$av_,"%/jf,8#~[^",j_Sf!`8fUy,zv#Fyq9;?1,"p2,K;bOB~T",pHNtJdHo[e,mxqXkoW;I],":+A,]QJt-"
+Tuvalu,"de=9c:,@j9",6QziO)s/Vz,5myhN(r.ry,ET[Oa;OLaK,AJ/nnIR/[0,e_%R[08+Z,IBl:CrljZo,BND}O4g5Z(,o6f7z~ZCr6
+United States Virgin Islands,kE!iKHLN_g,%)jU/A:GG9,$MiT.z/Fc8,wt]m$(ynIk,rB6=j&@4e&,pSK9uw6xC?,EwR<30)#1g,p~cba36}ll,jX.V=Tm<P3
+Åland Islands,d``B*6:eCx,6HH%qZw|&=,5dG$pYv{K<,dC[x.]4VGu,uL7#}Qw}D9,s{g7@QD$qr,ikT)0#7&yt,kZ;onU6NiN,eItZ|YXm$3
+South Ossetia,p]t8:Tka7q,"+E5hwMW^g,",*a4gvLV](+,w?1B]|VvAn,OawZ7gbEjw,jhuwlGqRkR,kAP^Ny~90T,oI5~{W$B0+,f*vz&Ph[bR
+American Samoa,niJUFZF$Y:,)U.^*S*5|N,(q-])R)46M,N?ze.ZE4@K,D=!L6rg_pr,cfXokA*89x,"u.[N1#,@y:","G.,g9N->(r",fsloLaTPf8
+Northern Mariana Islands,p}Qa|!7PpR,+K?MJ3gI1h,*g>LI2fHxg,DRS!iJyvJG,qOB6Gi<G=,t0QR1Q:HMY,xDK0`i2s%/,fITQ3o(eNJ,ga-I(hwLN)
+Aruba,uv1fGXHN@),":7aR+Q,GCG",/D~Q*P+F}F,L5qdsn2.Vt,"l(DiRV,GPj","e[{g,ks$!I",t9Ryk}`qj2,"vu]t,+fglW",AUgq3IkilN
+Abkhazia,sRw-ik:I$v,.@8tUdwBl;,-Z7sTcvA-:,u:[~?k7{9`,NH:[}beT-z,v6t>$<ADP[,PB_{Euk>>/,MZ+&Gti2z$,"w`;zj+qi],"
+Sint Maarten,bnEK#)[;qT,4Z)/k9D*2j,3v(.j8C)yi,ct@4i2c5]R,r8MKfCfg2E,i:L[HB&@F[,A)h(R4;N+m,Cr+mEZlgA:,Ar:~TK>ugF
+Republic of Artsakh,ey:Q|*t!Lg,7!w?J!53:9,6Gv>I942T8,Pki<F_#mJ$,b2PYE2BvAR,x]o%O2Wi4u,vPy3m1oa#d,AYOdHe0+qw,pbJ|E`wn_~
+Tonga,"c^,~EC6Pb2",5FsL)vfINs,4brK(ueHjr,v&W7WvlFQH,nJdfBSsZq=,ebha1T}R8+,d`zDA9y~gZ,J^vx<Yy&b%,"KG~t}M~,_o"
+Transnistria,tMMtBUpb$&,/;;5%N1_lE,.U:4$M0^-D,JS/Mu$zWXF,ox5y>?yriv,CP|Bi<B+3(,C&k%h=UUn#,Qm?>e]Q]ag,|*Z`50Bgs
+Sardinia,jKIDq|}J&c,$/-(2@KCn5,"#S,&1?JB/4",d*RV!D6_/z,"P%!7{$,zCG","i9-RjgM[_,","dzu,L2RTO6","CH0T!),h9{",qW1*i(&R3$
+Kaliningrad Oblast,dC:e5G4J/p,6&wQezdCv+,5KvPdycB[*,r6u%*kzI$i,t;/rK0Elxw,x`*~=TA+FK,CQXXs$n5cv,r+ehJ?q]D.,iZ`BoOu7TH
+Martinique,u;|vR#mVMW,:xJ7@4YO;m,/^I6?3XNUl,L{DDezoz^,s9/>8RT~Sr,bmb^QU~Z*k,xBC@m/Re-7,F[Xrq2xy>E,B=^Q!Oy7dx
+Java,gDsLPj(9S#,9(4:>co2[B,8L3/=bn10A,wao7Vn!%<:,"raobJ?,rJ[",P&j>MnZjBl,u~.<cG1`ob,A1z!_C=d(c,EykZ%2$zVY
+Corsica,xb&P*pH(Q,"qNEfq1,oJ",pjDe<0+nI,"B,.i%oyEc%",OB:w%H&-Al,FUCfa4kb<y,"B[,~m31[Og",HedPV<oAW~,P)2eJ7Sr]e
+European Union,Bszsaz0Iuo,[4#4Ms~B6*,@A!3Lr}AC),k9gbGeqVQp,IozRi;br@?,q9GttqBN(j,dIUwggycz7,FlmNG3Av;e,"Cj.2Qz[,?;"
+Gulf of Mexico,JOT:U4ayh@,~=]w^XMrTT,}W[v]WLqpS,N;|zJ3r1U0,BidEZ1j?sA,ujWW0n-WqL,fBT#}$9v{@,zy#+XVV9S`,mjltS8qw#I
+Philippine Sea,G/^_##fcPN,{vFGk4R`>d,`[EFj3Q_Xc,x!47n<n_@M,Q0Hf<s|zmU,u}sPj7cerL,uvRyF*9Zqg,DjNpq@BAMv,wN+#PV27nX
+Southern Ocean,LPF4AfaHKR,b>*d$}MA/h,aX)c#|LzSg,ilFuAD^xhq,"eyVn,2@529",Fs>y5(sRng,s^4z/0k+AF,jVChM/v;]D,DMw7[z1|/f
+Gulf of Thailand,rSneU!3}bn,-[ZQ^3c[N),",0YP]2b@j(",KfB$YBpp#=,s>VRzs_ra_,c!B%9S]zNK,Ej./VrJYpS,u@^{[]68&M,myDYy<t!DY
+Micronesia,cv+Nq9:a<P,57r<22w^yf,4Dq;11v]_e,oPx5Bq1z_~,nK_Xe;yw*A,gH(-5bzcUq,"Og]Pyc,dB|","q,Yx(B^2)]",e7aUv]y3NG
+Pacific Ocean,f*2@qiHh_1,"8qbC2b,aGr",7<aB1a+~cq,"xs+r,A:Ybh",Fe.owPPLXj,"g.N+uMm,{6",O6aT:6ldHZ,o2AxTxOe+;,fL<u4=Axl[
+Atlantic Ocean,nuU8A_$i2M,)6^h$=lbbc,(C]g#<ka!b,l:S1L#&(=-,v#9&oC&^gU,IS`eM7]t)I,xWSI:FF;%x,"e1k,rPrJXi",j65XMZPPCl
+Indian Ocean,fT!w8R#>dg,8]j8hKk-P9,"71i7gJj,l8",vV<w5Z&41M,zv;#VKpiyA,Ja&@${-ll#,EMPCtOx;Rj,fezBXMIU#+,taGg_[({a>
+Arctic Ocean,gG6SWfM>H0,"9+f[`};-,q","8Oe@_|:,Pp",l?;mPU|Vu$,msi&z%jb~L,f#ZCPMD62V,yXRb0bi*D.,ygzZMO52<5,"c3_S$ge,H%"
+Hudson Bay,sM0GPt1HS1,.;~+>maA[r,-U}*=l~z0q,g&y>f[SfCo,wt&@Z9Ke*y,I_$^q=J15;,"c3fq*,<:~U",RiU6/6cNcj,mVqJCtNO^w
+Labrador Sea,dlU7VG|3Gd,6X^g_zJW+6,5t]f^yIVO5,mC$X9cRfF4,i?3Cq]Y=6@,"O_++P3q,lg",D#f:CN7HH4,EV{1>IbA3.,f*A:Z4bkRD
+White Sea,cEO^y)Md[G,5)=F!9;{D{,4M<E98:`~`,CJHNGvTT1-,IHD#^9>(oF,yKo`$PaHGg,ym)YXCoojW,Ok!(($u.|p,ite]=1-[IW
+Denmark Strait,eN#^kPGv*L,7<kFWI+oqb,6VjEVH*n<a,c.@-5vbYSr,Bc^_k/M|{V,J9k3i5aRzz,"n!%,$ZZU.A",suwt).}j(N,sE1}%6$3D9
+Norwegian Sea,lp@e##m.!+,&1CQk4Y&jI,%xBPj3X%+H,Bvr#2W*V4O,ePFlYQsRPh,F9A3Lkp?+N,ds)Lw5L_oG,LoxeR.`jw@,li{q-g0Ru|
+Baltic Sea,epvt3>HH?U,"7175c-,ABk","6x64b,+z|j",HY(==0nL/5,lQbPlI/gwj,v]C@D/(-+g,Btv`iTH0LW,p}2F6mZ.QA,iWh/XzA:Fx
+Celtic Sea,E3u*2.<9#`,_c6qb&y2kY,"^#5pa%x1,X",x9m098F78O,c*=o}p_W/X,kn6vhJtt!Y,q]o/<>5}wu,bEhl$M2clS,QQ+*SW>?NN
+English Channel,q1Q3Do8S>g,",a?c(hhLA9",+9>b&ggK{8,QGDo{u)NuE,b~m$wS)FZZ,nlr&VdfBJA,M_Aq-@$=Ed,mUci[@*L<c,J{(N4{^e:N
+Adriatic Sea,yX:tmrd5;],>{w5YkPYxV,=5v4XjOX^U,"j7FyQaW,n{",x)A]S|GN_G,BLvM|PE:rh,M0{EnlSZ[&,CQTeWe?;Y/,GZ2yh|R:fR
+Bay of Biscay,H*c[ML+`s=,|qOD;Er>4Q,{<NC:Dq=AP,QwwgN[<duR,Aal{|%850},f.Z<UFi.{x,q}Pw=WLDWu,Ih-lfoAUWi,gx#n~i)Kft
+Black Sea,e_;dzXj8de,7GxP#QV1P7,6cwO!PU0l6,gb>Q&:;ekF,uge7s($h<X,wsM3JR2Xv?,od6cw^-E-],txn5MPFzv#,"sB,_Fhn5&I"
+Aegean Sea,iB-8Br~onq,"#%th%kLhZ,",!Jsg$jKgv+,dNo9L*#}F?,H)ax6=5vNG,G4|N9mDxa&,Ily]WmR8_^,*/b5m[q8j,xV<kEl1ZJ$
+Balkan Peninsula,zSc]-^U=0=,"?[OEt<^,~Q",>0NDs;]+8P,f^0aH]F%!V,td+]W)8y3S,l1uc5E8j;X,hpvj)-!USf,eY!@E#<EI8,lGG8WbUQzc
+Caspian Sea,x2d4n4ADcP,=bPdZX$wOf,<!OcYW#vke,kfniDM68Fr,B)~SL?|&BX,Rf#Y$PY2hD,J3~et+v|e@,cH2i]a9RGb,p6lxT;d^Pq
+Mediterranean Sea,Gn;q2Y)Xe4,{Zx2bRpQQu,`vw1aQoPmt,HG:Vbwri`^,"qoQ,f:/adY",x18Y%w8iOt,G!-:Hml<-@,McX+ixO5W@,ngPe&f4ARW
+East Siberian Sea,gRVZ]qJ#>O,9@_}Ej.4Ae,8Z^|Di-3{d,"QplodT,RlZ",GkU[4wRj6;,pvm.S00zT/,f-#kZAo/ON,I+N4^}Lq%;,ywSb;Oor?l
+Bering Strait,"J%,fuysl*&",~msR6r4eqE,}.rQ5q3d<D,b<9P_L#s6?,JffL}$<;][,AnHKmxdHRZ,etM=#0^o-o,M#?I9kQFyj,uxU}LMXAY+
+Arabian Sea,r(h9&#wc~B,-oTin48`L[,",:Shm37_h@",L}~TYYHI[l,nnM01DlaVX,h:!&t0Lvqc,i-&Ri-vDye,s$aq*|$f>s,z;zuT%S.hs
+Red Sea,_]DH+g9!$,=E^|rSij5,<a]{=Rhi4,Jt*Ggc<HyU,jH=<{Pcl+D,urEGY*T)mW,JS=q2$2L3],mJVG+OU2XO,g*C+;[^vP9
+Dead Sea,B:x<p&Q=t),"[w9y17?,5G",@]8x06>+BF,vhs6OnHZaA,J|aJY+vge3,d9jaR(A9o(,"D,@m:}o|sK",KNRlqLN%1t,"gn,]{C-kDK"
+Bay of Bengal,z:*d{z(~V2,?wqPIso]_s,>]pOHrn[3r,H1L?;^]mY],vJUDdBqkkp,c2(xx0>{|K,fs]5;0c;}B,ngbe6iK.Qu,x-s/YndH;0
+Sea of Japan,"d}R:qHj1,7",6K@w2AVUsx,5g?v1zUT>w,IG)L^LIKi],v/?czq&41s,nsv]+(L(N^,t$C>63YEjQ,q3=L7rObtd,pG~&s-.Pv=
+Yellow Sea,L5M1*yG7eH,be;aqr+0Q|,a%:~pq*Zm{,jcw8^HL&m5,F/|qA9Xb`f,bQ*]^-KLDC,EZvlR:83-^,J#7Tt[f!e*,iw)&(><6ju
+Coral Sea,"s|K&2S,UP|",.J/nbLsN>0,-f.maKrMXZ,P}xBc:eoH6,f)MSa#ZHdL,mH(F;!A-^i,MHvNbPV}Qa,B8UUt(OH@c,HeX)uooi/y
+South China Sea,t$y1C2R-Av,/l!a&V@%$;,.-9~%U?$I:,yu2IoRS.M),r%;LR/o1J0,gs<Y_*zj#^,Hmbq~BF@]H,pediB(:-]T,x*o*2(qrzU
+Tasman Sea,eHJ?)TAdTo,"7,.BpM${]*",6P-AoL#`1),k]|`O*|sYC,w[pneW3d#g,fL<HB36|&),v]|R(og)1x,oQ(1eJZ%h_,d/vX5sh?Z9
+Gulf of Carpentaria,pQpX%(EVOH,+?1{m8)O=|,*Y0`l7(NW{,HnPq%JW}F9,lzpJ#A4I81,kI#F9[@KH|,yB!Y:vm[{l,Kroi)OhVu,G&{G$z2N`]
+Aral Sea,qiv/4tOlf=,",U7vdm=eRQ",+q6ucl<dnP,BZ#71-])!<,pAb@53Gk?Y,k~[RV@<s7/,IW*fIQ@Vn!,M?CI|U:7E,cd@bD^dpRt
+Persian Gulf,M$bc0[jYf0,clNO~:VRRq,b-MN}/UQnp,hzN$`?YJ.^,ufv>~I-Znw,Ngx+p%Tn$u,v:EM)mKjX1,p><!jX(|}?,B4o4Qgpxa=
+Caribbean Sea,jYz[ibrr9m,$|#DU_3ki(,#6!CT^2j*&,H5FPagvP>_,u1C2Jtm-p^,iq(<JF$S6/,G:i:X<AqLs,qh#R8~1)v.,D.R!j]):&%
+Gulf of California,SlOEXfq#|,LXe_{R2k@,Ktd^5Q1j?,"FIQ,YV4(u",F[7BR94HX^,BU*(=#&k=b,Aa(5k`u_H.,CN1N1S@Hy[,"u>bFUX4,^("
+Polynesia,"d5m8%D6,;u",6eYhmwf$x:,5%Xglve#^/,FE||8n;*pO,c.$2jl~n2_,LXl!1P9Nfp,pj`8ER+@;H,B!be^2p5w-,t!YaMvtxM)
+Melanesia,o9{x<AyA]B,*iI9yt!tE[,)*H8xs9sa@,s~{9dxCHY+,NbC3xEVGZ},HiMLHEOc_m,gZA|73/rf@,I}SX`lcqJ9,fl~nzy1ZAc
+Scandinavia,He!e=h?_2V,|QjQzaB=bl,{miPy~A<!k,BLz2@~|QXB,Iu#Jjq4.-;,M(|D;@jB#D,N<Zjd9rV2&,AP>P}@<F6G,"Qqzh;Z,9&o"
+Sea of Galilee,QSq%~rFaP-,g[2mLk*^>K,f01lKj)]XJ,Q&)&?}53&@,yLhZzEnGK&,pi]:s4:9TG,Iktca^NUQ,C8l&[)j7Y),"A`,,|zaW//"
+Sumatra,ck!6;xK$/^,5Wjfxq/5vW,4siewp.4[V,bP[|CaNP86,E2:8?ZCW`=,D!9j=Ss[H),i2(em&ob8T,r)k(h&xdEF,vHOU`CM:P+
+Sicily,n{{o2K1:dw,)II0bDa)P<,(eHZaC~(l;,Ba#m$J?4gW,zBa]c`I@&q,s)}(&(C~qe,wj)M@s{]YR,jov_[O@hK6,bM>er*)`9o
+Mayotte,xqrJ^d[.(O,=23.F{D&oe,<y2-E`C%:d,Mie3UMRyst,cE|I9C6tDG,Gp?#Ik&V&F,b/*Gfh]U>A,ru#Hv&<OO[,g67ir]U+=9
+Réunion,vrn%j%6{nu,;3ZmV6f?Z:,:zYlU5e>v/,"n^,sUM_!k_",t1~2K{sjcs,IJ6D7S}LvU,nq{:LP(wy=,l$|!y^BHT^,F%kRV:W:T$
+Falkland Islands,p#R$-mG/L,ikhCtY+vE,"h,gB?X*uD",xAxtN`17x^,C+sW!v-+p],f[E%u}3F%e,hME8pvJ-]J,"sgfCxE,%}I",xA+]rlW|<7
+Europe,oV/JG7fwZq,"*_v.+0Rp},",)3u-*ZQo7+,B35In/Q=Tg,x-wPy%*F%3,Hm4bJ<Y`aA,ofER|_J~:`,Dp?|DrS.=x,dBTCh;2%Xv
+North America,bD?R}i8_[c,4(B@Kbh=D5,3LA?Jag<~4,GRj)gtiMbo,J[Z3=;n.`R,wsH3aZT9(O,k.2O4>+A!V,"E^e,*~,>&|",B0j5`h}ycY
+South America,Lol+XIvY21,b0Xr{B7Rbr,awWq`A6Q!q,l&Uv?yLL12,OGgh6NLJ_1,P4d|2~&E#h,z~`99rF8Y^,%Z}v@QXG-,AUQ5QqT7N~
+Asia,Qlib4)q2Hk,"gXUNd92V,%",ftTMc81UP$,bMX+]D]Ya>,Cay~/DU6[Y,x;/B{evQ?m,u9:IZ@Uo>l,gJpb~!c0G8,Lg|45@I{1+
+Africa,pwwZu{7f~(,+88}6?g}LF,*E7|5>f|hE,E9Y{~}fJ|q,q>RaVbPB3|,b~j)uKz$/r,NvOwi0qs57,FyYW/{EEO`,CpZYay1jbg
+Oceania,qFuGdDx^Yv,",*6+Pw9<|;",+N5*Ov8;6:,wx)T{wK99M,A.lC&CUT?S,lz;Aa8Mc)h,xfB@_iTV&b,A2*i`{j|[I,omFN1!]szI
+Antarctica,Cf2@;p<aL,vRsTx1yME,unrS^0xLD,vk=UoW^`zU,Q)zp&X@y?g,M%RATtq>65,h*-O8Wp^BE,]xe(O=bdk,DRY)+ITFX-
+Saint Martin,t2&ri|[Un:,/bn3U@DNZN,.!m2T?CMvM,Ek~&z$tb-I,Hg&j8uJWA$,o!L7Ln:)+/,cz=5m*@Fez,Q+I:vHQr7%,c7[u_eSWiy
 Wallis and Futuna,dbP/Cj}sB+,OjlKz@2/j+,B8+FHyt^E,rVJ^|c*{=!,vqay>V@}^.,IToJAz{P9K,s_iv#ETD^J,ftryRYGk$7,yychoEU/n9
 Akrotiri and Dhekelia,wa>{k!2cXc,"NnxZS,Tdmh","cv-,SC1HIr","Pz{%n/nX,I",kP@udSHU#/,wsB.ZRe68:,cPg&WpVKO~,"o3&;VW(Hf,",x=Gm50ksY@
 Svalbard,5JJ2]i)p4,cYp<xlh&6.,"f=r^TR.L0,",uE!R:a{FS{,E([1*B$wFU,Oh:F{^dxzr,n!&0937~y!,yXSMWI1KUx,"ch9]RU,k}a"


### PR DESCRIPTION
Fix #415.

I didn't change the ones that were already different to Spanish/English (i.e. everything from Wallis and Futuna onwards).

<details><summary>Double-check that the GUIDs for the other countries haven't changed at all</summary>

Run for `HEAD^` and `HEAD`:

```bash
csvtool namedcol country,guid,guid:de,guid:es,guid:cs,guid:ru,guid:nl,guid:sv src/data/guid.csv
```

and `diff` the outputs.

</details>

<details><summary>Check that the GUIDs are now all indeed unique</summary>

Run for `HEAD^` and `HEAD`:

```bash
csvtool cat -u TAB src/data/guid.csv | sed 's/\t/\n/g' | sort | uniq -c | sort | less
```

For the former, have some doublets (`    2 xxxxx`), as expected; for the latter have only one occurrence of each GUID, as desired.

</details>


<hr/>

Preliminary [FR/NB console scripts](https://gist.github.com/aplaice/aa6a54fa83696f2849e3834d79071214) — I'll properly test them and enter them (and the  [CS/NL/SV/RU scripts](https://gist.github.com/aplaice/865d93f11230ee438c0fff6da5832dca)) into the wiki, in the right places (and write appropriate descriptions).