### PR TITLE
Switch python version to 3.7

### DIFF
--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Set up Python 3.7
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 

--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -15,14 +15,13 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Install dependecies
-      uses: VaultVulp/action-pipenv@v2.0.1
-      with:
-        command: install
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pipenv
+        pipenv install
 
     - name: Validate
-      uses: VaultVulp/action-pipenv@v2.0.1
-      with:
-        command: run build
+      run: |
+        pipenv run build
 
       # TODO: Validate the csv file structure

--- a/.github/workflows/integrity-check.yml
+++ b/.github/workflows/integrity-check.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.7
 
     - name: Install dependecies
       uses: VaultVulp/action-pipenv@v2.0.1


### PR DESCRIPTION
(This is what's specified in our Pipfile and BrainBrew's.)

Hopefully, this will fix our integrity checks! (or not...)

(I'm not sure why/how they had been working previously — I'd guess that it was because Python 3.7 was already available in the "base image", and now the base image has been upgraded.)

(Edit: the python version should be completely irrelevant since `action-pipenv` runs in a docker container anyway...)