### PR TITLE
Replace "Downloads" with "Assets" in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ In order to install and later upgrade _Ultimate Geography_ you'll need to first 
 You're now ready to install _Ultimate Geography_:
 
 1. Go to the **[_Releases_ page](https://github.com/axelboc/anki-ultimate-geography/releases)**.
-1. In the latest release's _Downloads_ section, download the ZIP archive of the version of the deck you'd like to use. You can choose between [a standard and an extended version](#features) in a number of [languages](#ultimate-geography) -- for instance, if you're after the standard German deck, download `Ultimate_Geography_v[...]_DE.zip`.
+1. In the latest release's _Assets_ section, download the ZIP archive of the version of the deck you'd like to use. You can choose between [a standard and an extended version](#features) in a number of [languages](#ultimate-geography) -- for instance, if you're after the standard German deck, download `Ultimate_Geography_v[...]_DE.zip`.
 1. Extract the content of the archive on your computer.
 1. Open Anki and make sure your devices are all synchronised.
 1. In the _File_ menu, select _CrowdAnki: Import from disk_.


### PR DESCRIPTION
It seems like the installation instructions are talking about the section labeled "Assets" (when it says "Downloads"); this PR is to update that wording.