### PR TITLE
Change "Beweerd" to "Geclaimd" in Dutch capital hint

### DIFF
--- a/src/data/capital_hint.csv
+++ b/src/data/capital_hint.csv
@@ -2,6 +2,6 @@ country,capital hint,capital hint:de,capital hint:es,capital hint:fr,capital hin
 England,Not a sovereign country,Kein souveräner Staat,No es un país soberano,Pas une nation souveraine,Ikke selvstendig land,Nejedná se o suverénní stát,Не суверенная страна,Geen soevereine staat,Ej suverän stat,Não é um Estado soberano,不是主权国家
 United Kingdom,Sovereign country,Souveräner Staat,Es un país soberano,Nation souveraine,Selvstendig land,Suverénní stát,Суверенная страна,Souvereine staat,Suverän stat,Estado soberano,主权国家
 Israel,Claimed and controlled,Behauptet und kontrolliert,Reclamada y controlada,Revendiquée et contrôlée,Krevd og kontrollert,Nárokované a kontrolované,Заявленные и контролируемые,Geclaimd en gecontroleerd,Hävdas och kontrolleras,Reivindicado e controlado,声称对其拥有主权并拥有实际控制权
-Palestine,Claimed but not controlled,"Behauptet, aber nicht kontrolliert",Reclamada pero no controlada,Revendiquée mais non contrôlée,"Krevd, men ikke kontrollert","Nárokováno, ale nekontrolováno","Заявлено, но не контролируется",Beweerd maar niet gecontroleerd,Påstått men inte kontrollerat,"Reivindicada, mas não controlada",声称对其拥有主权但没有实际控制权
+Palestine,Claimed but not controlled,"Behauptet, aber nicht kontrolliert",Reclamada pero no controlada,Revendiquée mais non contrôlée,"Krevd, men ikke kontrollert","Nárokováno, ale nekontrolováno","Заявлено, но не контролируется",Geclaimd maar niet gecontroleerd,Påstått men inte kontrollerat,"Reivindicada, mas não controlada",声称对其拥有主权但没有实际控制权
 Puerto Rico,,,,,,,,,,Não é um Estado soberano,
 Antigua and Barbuda,,,,,,,,,,Estado soberano,


### PR DESCRIPTION
The word "Beweerd" is a translation of "Claimed" in another context, in this context "Geclaimd" is more accurate. It is also more consistent, as it is used in the translation for the hint of Israel.