### PR TITLE
Update CONTRIBUTING.md regarding editing guid.csv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,8 @@ This recipe allows editing the English standard or extended deck in Anki, and th
 - To **change the _Country_ field** of a note, change it in `main.csv`, `guid.csv`, `country.csv`, and any other derivative CSV in which the note appears.
 - To **add a new translation**, add a new column to each of the CSV files and name them as follows: `[field name]:[language code]` (e.g. `country info:fr`, all lowercase). In most cases, the language code should match the Wikipedia subdomain for that language (e.g. https://fr.wikipedia.org/).
 
+When editing `guid.csv` please try to avoid using a spreadsheet, if possible, and instead use a text editor (e.g. notepad) since spreadsheets mangle some of the GUIDs that start with `=` signs.
+
 > Adding new fields (e.g. population, currency, etc.), the most heavily requested change to the deck, will soon™ be solved using [Brain Brew][Brain Brew], by combining separate repositories. Stay tuned.
 
 ## Content inclusion rules


### PR DESCRIPTION
I think that we've had issues with spreadsheets changing some of the existing GUIDs to `Error:xxx` (in various languages) several times, now, which is probably rather annoying for our contributors. (For the latest see #538.)

Unfortunately, the CSV standard is under-defined and the "proper" behaviour of cells starting with an equals sign isn't really defined. (Python's CSV module thinks that a cell starting with an equals sign is just a raw value; most spreadsheets try to interpret such a cell as a formula.)

Ideally (as a proper solution), we'd either:
1. Avoid having equals signs at the start of GUIDs. (This can't be solved in the general case, since such GUIDs are valid, and Anki will continue generating such GUIDs occasionally (so users importing existing decks from Anki to Brain Brew will still have such GUIDs); however, in AUG we generate the GUIDs ourselves (via BrainBrew) so we could avoid creating such.) (We'd also obviously still have the problem of such existing GUIDs in AUG.)
2. Find a reliable way of "escaping" the equal signs at the start of GUIDs, that works with most spreadsheet programs. (This might be easier than 1.)