### PR TITLE
Updated German Translations for two Country Names

### DIFF
--- a/src/data/country.csv
+++ b/src/data/country.csv
@@ -102,10 +102,10 @@ Tanzania,Tansania,Tanzania,Tanzanie,Tanzania,Tanzanie,Танзания,Tanzania,
 Togo,Togo,Togo,Togo,Togo,Togo,Того,Togo,Togo,Togo,多哥(Togo),Togo
 Tunisia,Tunesien,Túnez,Tunisie,Tunisia,Tunisko,Тунис,Tunesië,Tunisien,Tunísia,突尼斯(Tunisia),Tunezja
 Uganda,Uganda,Uganda,Ouganda,Uganda,Uganda,Уганда,Oeganda,Uganda,Uganda,乌干达(Uganda),Uganda
-Sahrawi Arab Democratic Republic,Demokratische Arabische Republik Sahara (DARS),República Árabe Saharaui Democrática,République arabe sahraouie démocratique,Vest-Sahara,Saharská arabská demokratická republika,Сахарская Арабская Демократическая Республика,Sahrawi Arabische Democratische Republiek,Sahariska arabiska demokratiska republiken,República Árabe Saaraui Democrática (RASD),阿拉伯撒哈拉民主共和国(Sahrawi Arab Democratic Republic),Sahara Zachodnia
+Sahrawi Arab Democratic Republic,Demokratische Arabische Republik Sahara,República Árabe Saharaui Democrática,République arabe sahraouie démocratique,Vest-Sahara,Saharská arabská demokratická republika,Сахарская Арабская Демократическая Республика,Sahrawi Arabische Democratische Republiek,Sahariska arabiska demokratiska republiken,República Árabe Saaraui Democrática (RASD),阿拉伯撒哈拉民主共和国(Sahrawi Arab Democratic Republic),Sahara Zachodnia
 Zambia,Sambia,Zambia,Zambie,Zambia,Zambie,Замбия,Zambia,Zambia,Zâmbia,赞比亚(Zambia),Zambia
 Zimbabwe,Simbabwe,Zimbabue,Zimbabwe,Zimbabwe,Zimbabwe,Зимбабве,Zimbabwe,Zimbabwe,Zimbábue,津巴布韦(Zimbabwe),Zimbabwe
-Canary Islands,Kanarischen Inseln,Canarias,Îles Canaries,Kanariøyene,Kanárské ostrovy,Канарские Острова,Canarische Eilanden,Kanarieöarna,Ilhas Canárias,加那利群岛(Canary Islands),Wyspy Kanaryjskie
+Canary Islands,Kanarische Inseln,Canarias,Îles Canaries,Kanariøyene,Kanárské ostrovy,Канарские Острова,Canarische Eilanden,Kanarieöarna,Ilhas Canárias,加那利群岛(Canary Islands),Wyspy Kanaryjskie
 Afghanistan,Afghanistan,Afganistán,Afghanistan,Afghanistan,Afghánistán,Афганистан,Afghanistan,Afghanistan,Afeganistão,阿富汗(Afghanistan),Afganistan
 Bahrain,Bahrain,Baréin,Bahreïn,Bahrain,Bahrajn,Бахрейн,Bahrein,Bahrain,Barém,巴林(Bahrain),Bahrajn
 Bangladesh,Bangladesch,Bangladés,Bangladesh,Bangladesh,Bangladéš,Бангладеш,Bangladesh,Bangladesh,Bangladexe,孟加拉国(Bangladesh),Bangladesz


### PR DESCRIPTION
Updated the german translations for 

- Canary Islands
    - Was "Kanarischen Inseln", but should be "Kanarische Inseln" [Wikipedia DE](https://de.wikipedia.org/wiki/Kanarische_Inseln)
- Sahrawi Arab Democratic Republic
    - Was "Demokratische Arabische Republik Sahara (DARS)", but should be "Demokratische Arabische Republik Sahara" [Wikipedia DE](https://de.wikipedia.org/wiki/Demokratische_Arabische_Republik_Sahara)