### PR TITLE
Fixes TemplateError when Importing Extended Deck 

### DIFF
--- a/src/note_models/Ultimate_Geography_[Extended].yaml
+++ b/src/note_models/Ultimate_Geography_[Extended].yaml
@@ -28,6 +28,6 @@ templates:
   - name: Flag - Country
     html_file: src/note_models/templates/Flag - Country.html
   - name: Country - Map
-    html_file: src/note_models/templates/Map - Country.html
+    html_file: src/note_models/templates/Country - Map.html
   - name: Map - Country
     html_file: src/note_models/templates/Map - Country.html


### PR DESCRIPTION
When testing my other PR I was not able to import the extended deck from the current master branch, because I got the following error:

`anki.errors.TemplateError: Card template ⁨6⁩ in notetype '⁨Ultimate Geography [Extended]⁩' has a problem.<br>The front side is identical to card template ⁨5⁩.`

Therefore in `src/note_models/Ultimate_Geography_[Extended].yaml`, I changed the HTML template for `Country - Map` from `Map - Country.html` to  `Country - Map.html`. I guess this was a refactoring error. After changing that, the import for the extended deck works now. However, I am not very familiar with Brain Brew or Crowd Anki, so maybe there needs to be a change somewhere else too.