### PR TITLE
Fix capitalization of Eswatini

### DIFF
--- a/src/data/country.csv
+++ b/src/data/country.csv
@@ -97,7 +97,7 @@ Seychelles,Seychellen,Seychelles,Seychelles,Seychellene,Seychely,Сейшель�
 Sierra Leone,Sierra Leone,Sierra Leona,Sierra Leone,Sierra Leone,Sierra Leone,Сьерра-Леоне,Sierra Leone,Sierra Leone,Serra Leoa,塞拉利昂(Sierra Leone),Sierra Leone,Sierra Leone
 South Africa,Südafrika,Sudáfrica,Afrique du Sud,Sør-Afrika,Jihoafrická republika,Южно-Африканская Республика,Zuid-Afrika,Sydafrika,África do Sul,南非(South Africa),Południowa Afryka,Sudafrica
 Sudan,Sudan,Sudán,Soudan,Sudan,Súdán,Судан,Soedan,Sudan,Sudão,苏丹(Sudan),Sudan,Sudan
-Eswatini,Eswatini,Suazilandia,Eswatini,Eswatini,Svazijsko,Эсватини,eSwatini,Swaziland,Essuatíni,埃斯瓦蒂尼(Eswatini),Eswatini,eSwatini
+Eswatini,Eswatini,Suazilandia,Eswatini,Eswatini,Svazijsko,Эсватини,Eswatini,Swaziland,Essuatíni,埃斯瓦蒂尼(Eswatini),Eswatini,eSwatini
 Tanzania,Tansania,Tanzania,Tanzanie,Tanzania,Tanzanie,Танзания,Tanzania,Tanzania,Tanzânia,坦桑尼亚(Tanzania),Tanzania,Tanzania
 Togo,Togo,Togo,Togo,Togo,Togo,Того,Togo,Togo,Togo,多哥(Togo),Togo,Togo
 Tunisia,Tunesien,Túnez,Tunisie,Tunisia,Tunisko,Тунис,Tunesië,Tunisien,Tunísia,突尼斯(Tunisia),Tunezja,Tunisia


### PR DESCRIPTION
Although some spellings seem to use capitalization in the middle of the word (?), the Dutch name does not.
https://nl.wikipedia.org/wiki/Swaziland