### PR TITLE
Small changes / additions (T&C Eilanden, Malediven, Oostzee)

### DIFF
--- a/src/data/country.csv
+++ b/src/data/country.csv
@@ -129,7 +129,7 @@ Kyrgyzstan,Kirgisistan,Kirguistán,Kirghizistan,Kirgisistan,Kyrgyzstán,Кирг
 Kuwait,Kuwait,Kuwait,Koweït,Kuwait,Kuvajt,Кувейт,Koeweit,Kuwait,Kuwait,科威特(Kuwait),Kuwejt,Kuwait
 Myanmar,Myanmar,Birmania,Birmanie,Myanmar,Myanmar,Мьянма,Myanmar,Myanmar,Mianmar,缅甸(Myanmar),Mjanma,Birmania
 Mongolia,Mongolei,Mongolia,Mongolie,Mongolia,Mongolsko,Монголия,Mongolië,Mongoliet,Mongólia,蒙古(Mongolia),Mongolia,Mongolia
-Maldives,Malediven,Maldivas,Maldives,Maldivene,Maledivy,Мальдивы,Maldiven,Maldiverna,Maldivas,马尔代夫(Maldives),Malediwy,Maldive
+Maldives,Malediven,Maldivas,Maldives,Maldivene,Maledivy,Мальдивы,Malediven,Maldiverna,Maldivas,马尔代夫(Maldives),Malediwy,Maldive
 Malaysia,Malaysia,Malasia,Malaisie,Malaysia,Malajsie,Малайзия,Maleisië,Malaysia,Malásia,马来西亚(Malaysia),Malezja,Malaysia
 Oman,Oman,Omán,Oman,Oman,Omán,Оман,Oman,Oman,"Omã (BR), Omão (PT)",阿曼(Oman),Oman,Oman
 Nepal,Nepal,Nepal,Népal,Nepal,Nepál,Непал,Nepal,Nepal,Nepal,尼泊尔(Nepal),Nepal,Nepal
@@ -206,7 +206,7 @@ Saint Lucia,St. Lucia,Santa Lucía,Sainte-Lucie,Saint Lucia,Svatá Lucie,Сен�
 Bali,Bali,Bali,Bali,Bali,Bali,Бали,Bali,Bali,Bali,巴厘岛(Bali),Bali,Bali
 Grenada,Grenada,Granada,Grenade,Grenada,Grenada,Гренада,Grenada,Grenada,Granada,格林纳达(Grenada),Grenada,Grenada
 British Virgin Islands,Britische Jungferninseln,Islas Vírgenes Británicas,Îles Vierges britanniques,De britiske Jomfruøyer,Britské Panenské ostrovy,Британские Виргинские Острова,Britse Maagdeneilanden,Brittiska Jungfruöarna,Ilhas Virgens Britânicas,英属维尔京群岛(British Virgin Islands),Brytyjskie Wyspy Dziewicze,Isole Vergini britanniche
-Turks and Caicos Islands,Turks- und Caicosinseln,Islas Turcas y Caicos,Îles Turques-et-Caïques,Turks- og Caicosøyene,Turks a Caicos,Острова Теркс и Кайкос,Turks-en Caicoseianden,Turks- och Caicosöarna,Turcas e Caicos,特克斯和凯科斯群岛(Turks and Caicos Islands),Wyspy Turks i Caicos,Turks e Caicos
+Turks and Caicos Islands,Turks- und Caicosinseln,Islas Turcas y Caicos,Îles Turques-et-Caïques,Turks- og Caicosøyene,Turks a Caicos,Острова Теркс и Кайкос,Turks-en Caicoseilanden,Turks- och Caicosöarna,Turcas e Caicos,特克斯和凯科斯群岛(Turks and Caicos Islands),Wyspy Turks i Caicos,Turks e Caicos
 Cayman Islands,Cayman Islands (Kaimaninseln),Islas Caimán,Îles Caïmans,Caymanøyene,Kajmanské ostrovy,Каймановы острова,Kaaimaneilanden,Caymanöarna,Ilhas Caimã,开曼群岛(Cayman Islands),Kajmany,Isole Cayman
 Anguilla,Anguilla,Anguila,Anguilla,Anguilla,Anguilla,Ангилья,Anguilla,Anguilla,Anguila,安圭拉(Anguilla),Anguilla,Anguilla
 Azores,Azoren (Habichtsinseln),Azores,Açores,Asorene,Azory,Азорские острова,Azoren,Azorerna,Açores,亚速尔群岛(Azores),Azory,Azzorre

--- a/src/data/country_info.csv
+++ b/src/data/country_info.csv
@@ -77,7 +77,7 @@ Indian Ocean,,,,,Også kalt Indiahavet.,,,,,,,,
 Arctic Ocean,,"Auch Nordpolarmeer, nördliches Eismeer, Arktische See oder Arktik.",,,,,,,,,,Znany także jako Ocean Północny lub Morze Arktyczne.,Conosciuto a livello internazionale come Oceano Artico.
 White Sea,,Auch Weißmeer.,,,Også kalt Hvitehavet.,,,,,,,,
 Norwegian Sea,,Auch Norwegische See/Meer.,,,,,,,,,,,
-Baltic Sea,,Auch Baltisches Meer.,,,Også kalt Det baltiske hav.,,,,,,,,
+Baltic Sea,,Auch Baltisches Meer.,,,Også kalt Det baltiske hav.,,,Ook wel Baltische Zee.,,,,,
 Bay of Biscay,,Auch Golf von Biskaya.,,,,,,,,,,,
 Aegean Sea,,Auch Ägäis.,,,,,,,,,,,
 Balkan Peninsula,,Auch Balkan.,,,Også kalt Balkanhalvøya.,,,,Även känt som Balkan.,,,,
@@ -110,3 +110,4 @@ Namibia,,,,,,,Ранее известна как Юго-Западная Афр�
 English Channel,,,,,,,Также известен как Английский канал,,,,,,
 South Africa,,,,,,,,,,,,Znana także jako RPA (Republika Południowej Afryki).,
 Sea of Galilee,,,,,,,,"Ook wel Meer van Kinneret, Meer van Galilea of Meer van Genezareth genoemd.",,,,,
+Maldives,,,,,,,,"Ook wel Maldiven genoemd.",,,,,


### PR DESCRIPTION
1) Fix a taipoh, 'eianden' should be 'eilanden'. https://nl.wikipedia.org/wiki/Turks-_en_Caicoseilanden

2) Malediven is more common in Dutch. https://nl.wikipedia.org/wiki/Malediven 

3) Baltic sea is also a very common alternative name. https://nl.wikipedia.org/wiki/Oostzee