### PR TITLE
Add brief link to Wiki page describing card mappings to switch decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If you're upgrading from v3.3 or earlier, then you may want to additionally foll
 
 If you've made, or are thinking of making, any changes to your _Ultimate Geography_ deck, check the [_Customising the deck_](#customising-the-deck) section below to see what will happen to them the next time you upgrade, and whether you need to take any steps to preserve them.
 
-### Levelling up from standard to extended
+### Levelling up from standard to extended (or to experimental)
 
 Importing an extended deck on top of a standard deck is tricky and needs care. You may instead consider learning the extended deck from scratch. To do so, either:
 
@@ -145,6 +145,8 @@ If you'd rather keep your progress, proceed as follows:
 1. Perform the _Getting started_ steps exactly.
 1. Instead of a dialog box confirming that the import was successful, you'll see another dialog box titled _Change Note Type_. In the _Cards_ section, set _Change Flag - Country to:_ to "Flag - Country" (instead of "Country - Flag"), and set _Change Map - Country to:_ to "Map - Country" (instead of "Flag - Country").
 1. Check that the other cards and fields map correctly and click on _OK_ to start the import.
+
+The "mappings" for switching from standard to extended, as well as for all currently possible deck type changes are shown in tabular format [here](https://github.com/anki-geo/ultimate-geography/wiki/Switching-deck-type#specific-guides).
 
 ### Major version
 


### PR DESCRIPTION
TBH I'm not sure if this is needed for now.

We can link to the Wiki page wherever we advertise the new interactive deck, and we can more prominently link the page in the README when we adjust it to better describe the interactive deck once it's more "stable".