### PR TITLE
Add alternative name of Turkey

### DIFF
--- a/src/data/country_info.csv
+++ b/src/data/country_info.csv
@@ -110,3 +110,4 @@ English Channel,,,,,,,Также известен как Английский к
 South Africa,,,,,,,,,,,,Znana także jako RPA (Republika Południowej Afryki).,,
 Sea of Galilee,,,,,,,,"Ook wel Meer van Kinneret, Meer van Galilea of Meer van Genezareth genoemd.",,,,,,
 Maldives,,,,,,,,Ook wel Maldiven genoemd.,,,,,,
+Turkey,Also known as Türkiye,,,,,,,,,,,,,


### PR DESCRIPTION
Fix #645.

This is a minor difference, but I think that it should be included especially given the importance attached to this by the Turkish government.

AFAICT Wikipedia in no other language includes Türkiye as a name in the given language (even though they do often say "in Turkish: called Türkiye"), so I think this should be in English only.