### PR TITLE
Add script for zipping decks for releases/sharing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -397,6 +397,7 @@ Content changes, such as adding a note, replacing an image, or translating the d
 1. Add each folder in the `build` directory to a separate ZIP archive named as follows:
    - `Ultimate Geography [EN]` ==> `Ultimate_Geography_v[x.y]_EN.zip`.
    - `Ultimate Geography [EN] [Extended]` ==> `Ultimate_Geography_v[x.y]_EN_EXTENDED.zip`.
+   This can be done with `pipenv run zip`.
 1. On GitHub, create a new **release** named after the version number.
 1. Draft the release notes, making sure to add a link to the upgrade steps in the `README` and/or [in the wiki](https://github.com/anki-geo/ultimate-geography/wiki/Upgrade-instructions).
 1. Attach all the ZIP files and save the draft release notes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -392,7 +392,7 @@ Content changes, such as adding a note, replacing an image, or translating the d
 1. Run `pipenv run build`.
 1. In Anki, synchronise all your devices then upgrade the standard English deck by following the recommended procedure, which was agreed upon in the discussion thread. Synchronise all your devices again once the upgrade is complete.
 1. With the help of the Anki card browser, update the notes/cards stats in both `desc.html` and `README.md`, and commit the changes (including the version bump).
-1. Run `pipenv run build` again.
+1. Run `pipenv run build` again. If there is an experimental deck to be released, also run `pipenv run build_experimental`.
 1. Reimport the standard English deck in Anki and synchronise with AnkiWeb.
 1. Add each folder in the `build` directory to a separate ZIP archive named as follows:
    - `Ultimate Geography [EN]` ==> `Ultimate_Geography_v[x.y]_EN.zip`.

--- a/Pipfile
+++ b/Pipfile
@@ -14,3 +14,4 @@ python_version = "3.11"
 [scripts]
 build = "brain_brew run recipes/source_to_anki.yaml"
 build_experimental = "brain_brew run recipes/source_to_anki_[experimental].yaml"
+zip = "python utils/zip_decks.py"

--- a/utils/zip_decks.py
+++ b/utils/zip_decks.py
@@ -1,0 +1,63 @@
+import re
+
+from zipfile import ZipFile, ZIP_DEFLATED
+from pathlib import Path
+
+# Adapted from https://github.com/python/cpython/blob/3.13/Lib/zipfile/__init__.py#L2328
+def addToZip(zf, path, zippath):
+    if path.is_file():
+        zf.write(path, zippath, ZIP_DEFLATED)
+    elif path.is_dir():
+        if zippath:
+            zf.write(path, zippath)
+        for nm in sorted(path.iterdir()):
+            addToZip(zf,
+                     nm, zippath / nm.name)
+
+DECK_DIR_REGEXP = re.compile(r"^Ultimate Geography \[([A-Z-]*)\] ?(|\[Extended\]|\[Experimental\])$")
+def get_zip_filename(deck_dir, version):
+    m = DECK_DIR_REGEXP.match(deck_dir)
+    if m is not None:
+        lang_code = m.group(1)
+        deck_type = m.group(2)
+
+        if deck_type == "[Extended]":
+            deck_type = "_EXTENDED"
+        elif deck_type == "[Experimental]":
+            deck_type = "_EXPERIMENTAL"
+        elif deck_type == "":
+            deck_type = ""
+        else:
+            raise ValueError(f"Unknown deck type: {deck_type}")
+
+        return f"Ultimate_Geography_{version}_{lang_code}{deck_type}.zip"
+
+    else:
+        raise ValueError(f"Unexpected deck directory name: {deck_dir}")
+
+# Allow passing version string manually!
+def zip_decks(aug_version=None):
+    root = Path.cwd()
+
+    build_dir = root / "build"
+
+    desc_file = root / "src" / "headers" / "desc.html"
+    if aug_version is None:
+        with open(desc_file) as f:
+            desc_text = f.read()
+        m = re.search(r"Ultimate Geography (v[0-9]+\.[0-9]+)", desc_text)
+        if m is None:
+            raise ValueError("Description file does not contain version string!")
+        aug_version = m.group(1)
+
+    if build_dir.is_dir():
+        for deck_dir in build_dir.iterdir():
+            if deck_dir.is_dir():
+                deck_dir_name = deck_dir.name
+                zip_name = build_dir / get_zip_filename(deck_dir_name, aug_version)
+                with ZipFile(zip_name, "w") as zf:
+                    addToZip(zf, deck_dir, Path(deck_dir_name))
+
+
+if __name__ == "__main__":
+    zip_decks()


### PR DESCRIPTION
This was originally designed for the automatic uploading of files to the unofficial "everfresh" release in my personal fork, and still keeps the parts of the code relevant only to that purpose.

I'm not at all sure whether this needs to be included in the main repo (I'm happy to keep it in my personal files), but I thought it might be worth it as simple, but useful maintenance code.

(_If_ we are to include it, it might be preferable to move it into some subfolder or to remove the old github-CI-specific parts of the code.  (OTOH if we do figure out a way to run attaching files to releases in GitHub actions in a safe way, this code might turn out to be useful in the main repo, as well.))