### PR TITLE
Update flag of Hungary based on Wikimedia

### DIFF
--- a/src/media/flags/ug-flag-hungary.svg
+++ b/src/media/flags/ug-flag-hungary.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="500" height="250" viewBox="0 0 6 3"><path fill="#436F4D" d="M0 0h6v3H0z"/><path fill="#FFF" d="M0 0h6v2H0z"/><path fill="#CD2A3E" d="M0 0h6v1H0z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="250" viewBox="0 0 1200 600"><path fill="#477050" d="M0 0h1200v600H0"/><path fill="#fff" d="M0 0h1200v400H0"/><path fill="#ce2939" d="M0 0h1200v200H0"/></svg>


### PR DESCRIPTION
Fix #704.

AFAIU this is not a change due to external (legal) changes, but based on what Wikipedia decided is the correct choice of flag colours.  (The new colours are the legally/officially-specified colours.)

The new, updated flag has been on Wikipedia since 4 January 2023, so it's relatively unlikely to be a temporary "edit war" version.